### PR TITLE
Legger til scemas for Keycloak og AMQ, samt korrigering av doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openshift-schema-manifest
 
-Dette depoet inneholder genererte schema for Openshift. Disse benyttes i forbindelse med validering av endringer i [k8s-applications](https://github.com/domstolene/k8s-applications).
+Dette depoet inneholder genererte schema for Openshift. Disse benyttes i forbindelse med validering av endringer i [k8s-applications](https://github.com/domstolene/k8s-applications). Legges det til nye CRD-er, operatorer etc. Må disse inn her for at valideringen skal gå gjennom.
 
 For å oppdatere dette depotet logger man først inn på OpenShift, deretter kjører man:
 
@@ -14,12 +14,11 @@ python3 ./scripts/build_schema.py \
 Dernest:
 
 ```sh
-python3 ./scripts/build_schema.py --strict \
+python3 ./scripts/build_schema.py \
 --url $(oc whoami --show-server) \
 --token $(oc whoami -t) \
---destination ./openshift-json-schema/
+--destination ./openshift-json-schema/ \
+--strict true
 ```
-
-
 
 Se [Validating OpenShift Manifests in a GitOps World](https://cloud.redhat.com/blog/validating-openshift-manifests-in-a-gitops-world) for bakgrunnen til dette opplegget.

--- a/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha1.json
@@ -1,0 +1,455 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha2.json
@@ -1,0 +1,486 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha2"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha3.json
@@ -1,0 +1,1053 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "amqpMinLargeMessageSize": {
+                "description": "The default value is 102400 (100KBytes). Setting it to -1 will disable large message support.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "addressSettings": {
+          "description": "a list of address settings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "addressSetting": {
+              "description": "address setting configuration",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addressFullPolicy": {
+                    "description": "what happens when an address where maxSizeBytes is specified becomes full",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "DROP",
+                      "FAIL",
+                      "PAGE",
+                      "BLOCK"
+                    ]
+                  },
+                  "autoCreateAddresses": {
+                    "description": "whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateDeadLetterResources": {
+                    "description": "whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateExpiryResources": {
+                    "description": "whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsQueues": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsTopics": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateQueues": {
+                    "description": "whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddresses": {
+                    "description": "whether or not to delete auto-created addresses when it no longer has any queues",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddressesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteCreatedQueues": {
+                    "description": "whether or not to delete created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsQueues": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsTopics": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueues": {
+                    "description": "whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesMessageCount": {
+                    "description": "the message count the queue must be at or below before it can be evaluated  to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "configDeleteAddresses": {
+                    "description": "What to do when an address is no longer in broker.xml. OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "configDeleteQueues": {
+                    "description": "What to do when a queue is no longer in broker.xml. OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "deadLetterAddress": {
+                    "description": "the address to send dead messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueuePrefix": {
+                    "description": "the prefix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueueSuffix": {
+                    "description": "the suffix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultAddressRoutingType": {
+                    "description": "the routing-type used on auto-created addresses",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultConsumerWindowSize": {
+                    "description": "the default window size for a consumer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultConsumersBeforeDispatch": {
+                    "description": "the default number of consumers needed before dispatch can start for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultDelayBeforeDispatch": {
+                    "description": "the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultExclusiveQueue": {
+                    "description": "whether to treat the queues under the address as exclusive queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupBuckets": {
+                    "description": "number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupFirstKey": {
+                    "description": "key used to mark a message is first in a group for a consumer",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalance": {
+                    "description": "whether to rebalance groups when a consumer is added",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalancePauseDispatch": {
+                    "description": "whether to pause dispatch when rebalancing groups",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueKey": {
+                    "description": "the property to use as the key for a last value queue by default",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueQueue": {
+                    "description": "whether to treat the queues under the address as a last value queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultMaxConsumers": {
+                    "description": "the maximum number of consumers allowed on this queue at any one time",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultNonDestructive": {
+                    "description": "whether the queue should be non-destructive by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultPurgeOnNoConsumers": {
+                    "description": "purge the contents of the queue once there are no consumers",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultQueueRoutingType": {
+                    "description": "the routing-type used on auto-created queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultRingSize": {
+                    "description": "the default ring-size value for any matching queue which doesnt have ring-size explicitly defined",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "enableMetrics": {
+                    "description": "whether or not to enable metrics for metrics plugins on the matching address",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiryAddress": {
+                    "description": "the address to send expired messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryDelay": {
+                    "description": "Overrides the expiration time for messages using the default value for expiration time. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "expiryQueuePrefix": {
+                    "description": "the prefix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryQueueSuffix": {
+                    "description": "the suffix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastValueQueue": {
+                    "description": "This is deprecated please use default-last-value-queue instead.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "managementBrowsePageSize": {
+                    "description": "how many message a management resource can browse",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "match": {
+                    "description": "pattern for matching settings against addresses; can use wildards",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxDeliveryAttempts": {
+                    "description": "how many times to attempt to deliver a message before sending to dead letter address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a higher value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxRedeliveryDelay": {
+                    "description": "Maximum value for the redelivery-delay",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytes": {
+                    "description": "the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytesRejectThreshold": {
+                    "description": "used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only. Default = -1 (no limit).",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "messageCounterHistoryDayLimit": {
+                    "description": "how many days to keep message counter history for this address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "minExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a lower value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageMaxCacheSize": {
+                    "description": "Number of paging files to cache in memory to avoid IO during paging navigation",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageSizeBytes": {
+                    "description": "The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "redeliveryCollisionAvoidanceFactor": {
+                    "description": "factor by which to modify the redelivery delay slightly to avoid collisions",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelay": {
+                    "description": "the time (in ms) to wait before redelivering a cancelled message.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelayMultiplier": {
+                    "description": "multiplier to apply to the redelivery-delay",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redistributionDelay": {
+                    "description": "how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "retroactiveMessageCount": {
+                    "description": "the number of messages to preserve for future queues created on the matching address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "sendToDlaOnNoRoute": {
+                    "description": "if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerCheckPeriod": {
+                    "description": "How often to check for slow consumers on a particular queue. Measured in seconds.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerPolicy": {
+                    "description": "what happens when a slow consumer is identified",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "KILL",
+                      "NOTIFY"
+                    ]
+                  },
+                  "slowConsumerThreshold": {
+                    "description": "The minimum rate of message consumption allowed before a consumer is considered \"slow.\" Measured in messages-per-second.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "applyRule": {
+              "description": "a flag APPLY_RULE that indicates on what parts of address settings in broker.xml to perform the merge. It has 3 possible values: =replace_all The merge performs merge on the address-settings as a whole part. =merge_replace The merge performs merge on each address-setting element =merge_all The merge performs merge on each property of every address-setting This is the default value",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resources": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            },
+            "storage": {
+              "description": "the storage capacity",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "size": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha3"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha4.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha4.json
@@ -1,0 +1,1074 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha4"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "amqpMinLargeMessageSize": {
+                "description": "The default value is 102400 (100KBytes). Setting it to -1 will disable large message support.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "addressSettings": {
+          "description": "a list of address settings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "addressSetting": {
+              "description": "address setting configuration",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addressFullPolicy": {
+                    "description": "what happens when an address where maxSizeBytes is specified becomes full",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "DROP",
+                      "FAIL",
+                      "PAGE",
+                      "BLOCK"
+                    ]
+                  },
+                  "autoCreateAddresses": {
+                    "description": "whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateDeadLetterResources": {
+                    "description": "whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateExpiryResources": {
+                    "description": "whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsQueues": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsTopics": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateQueues": {
+                    "description": "whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddresses": {
+                    "description": "whether or not to delete auto-created addresses when it no longer has any queues",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddressesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteCreatedQueues": {
+                    "description": "whether or not to delete created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsQueues": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsTopics": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueues": {
+                    "description": "whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesMessageCount": {
+                    "description": "the message count the queue must be at or below before it can be evaluated  to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "configDeleteAddresses": {
+                    "description": "What to do when an address is no longer in broker.xml. OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "configDeleteQueues": {
+                    "description": "What to do when a queue is no longer in broker.xml. OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "deadLetterAddress": {
+                    "description": "the address to send dead messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueuePrefix": {
+                    "description": "the prefix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueueSuffix": {
+                    "description": "the suffix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultAddressRoutingType": {
+                    "description": "the routing-type used on auto-created addresses",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultConsumerWindowSize": {
+                    "description": "the default window size for a consumer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultConsumersBeforeDispatch": {
+                    "description": "the default number of consumers needed before dispatch can start for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultDelayBeforeDispatch": {
+                    "description": "the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultExclusiveQueue": {
+                    "description": "whether to treat the queues under the address as exclusive queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupBuckets": {
+                    "description": "number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupFirstKey": {
+                    "description": "key used to mark a message is first in a group for a consumer",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalance": {
+                    "description": "whether to rebalance groups when a consumer is added",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalancePauseDispatch": {
+                    "description": "whether to pause dispatch when rebalancing groups",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueKey": {
+                    "description": "the property to use as the key for a last value queue by default",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueQueue": {
+                    "description": "whether to treat the queues under the address as a last value queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultMaxConsumers": {
+                    "description": "the maximum number of consumers allowed on this queue at any one time",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultNonDestructive": {
+                    "description": "whether the queue should be non-destructive by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultPurgeOnNoConsumers": {
+                    "description": "purge the contents of the queue once there are no consumers",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultQueueRoutingType": {
+                    "description": "the routing-type used on auto-created queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultRingSize": {
+                    "description": "the default ring-size value for any matching queue which doesnt have ring-size explicitly defined",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "enableMetrics": {
+                    "description": "whether or not to enable metrics for metrics plugins on the matching address",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiryAddress": {
+                    "description": "the address to send expired messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryDelay": {
+                    "description": "Overrides the expiration time for messages using the default value for expiration time. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "expiryQueuePrefix": {
+                    "description": "the prefix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryQueueSuffix": {
+                    "description": "the suffix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastValueQueue": {
+                    "description": "This is deprecated please use default-last-value-queue instead.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "managementBrowsePageSize": {
+                    "description": "how many message a management resource can browse",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "match": {
+                    "description": "pattern for matching settings against addresses; can use wildards",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxDeliveryAttempts": {
+                    "description": "how many times to attempt to deliver a message before sending to dead letter address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a higher value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxRedeliveryDelay": {
+                    "description": "Maximum value for the redelivery-delay",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytes": {
+                    "description": "the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytesRejectThreshold": {
+                    "description": "used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only. Default = -1 (no limit).",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "messageCounterHistoryDayLimit": {
+                    "description": "how many days to keep message counter history for this address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "minExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a lower value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageMaxCacheSize": {
+                    "description": "Number of paging files to cache in memory to avoid IO during paging navigation",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageSizeBytes": {
+                    "description": "The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "redeliveryCollisionAvoidanceFactor": {
+                    "description": "factor by which to modify the redelivery delay slightly to avoid collisions",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelay": {
+                    "description": "the time (in ms) to wait before redelivering a cancelled message.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelayMultiplier": {
+                    "description": "multiplier to apply to the redelivery-delay",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redistributionDelay": {
+                    "description": "how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "retroactiveMessageCount": {
+                    "description": "the number of messages to preserve for future queues created on the matching address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "sendToDlaOnNoRoute": {
+                    "description": "if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerCheckPeriod": {
+                    "description": "How often to check for slow consumers on a particular queue. Measured in seconds.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerPolicy": {
+                    "description": "what happens when a slow consumer is identified",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "KILL",
+                      "NOTIFY"
+                    ]
+                  },
+                  "slowConsumerThreshold": {
+                    "description": "The minimum rate of message consumption allowed before a consumer is considered \"slow.\" Measured in messages-per-second.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "applyRule": {
+              "description": "a flag APPLY_RULE that indicates on what parts of address settings in broker.xml to perform the merge. It has 3 possible values: =replace_all The merge performs merge on the address-settings as a whole part. =merge_replace The merge performs merge on each address-setting element =merge_all The merge performs merge on each property of every address-setting This is the default value",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "initImage": {
+              "description": "The init container image used to configure broker addresssettings",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "jolokiaAgentEnabled": {
+              "description": "If true enable the Jolokia JVM Agent",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "managementRBACEnabled": {
+              "description": "If true enable the management role based access control",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resources": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            },
+            "storage": {
+              "description": "the storage capacity",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "size": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha4"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha5.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemis-broker-v2alpha5.json
@@ -1,0 +1,1223 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha5"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "amqpMinLargeMessageSize": {
+                "description": "The default value is 102400 (100KBytes). Setting it to -1 will disable large message support.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name does not match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "supportAdvisory": {
+                "description": "For openwire protocol if advisory topics are enabled, default false",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "suppressInternalManagementObjects": {
+                "description": "If prevents advisory addresses/queues to be registered to management service, default false",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting clients SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "addressSettings": {
+          "description": "a list of address settings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "addressSetting": {
+              "description": "address setting configuration",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addressFullPolicy": {
+                    "description": "what happens when an address where maxSizeBytes is specified becomes full",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "DROP",
+                      "FAIL",
+                      "PAGE",
+                      "BLOCK"
+                    ]
+                  },
+                  "autoCreateAddresses": {
+                    "description": "whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateDeadLetterResources": {
+                    "description": "whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateExpiryResources": {
+                    "description": "whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsQueues": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsTopics": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateQueues": {
+                    "description": "whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddresses": {
+                    "description": "whether or not to delete auto-created addresses when it no longer has any queues",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddressesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteCreatedQueues": {
+                    "description": "whether or not to delete created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsQueues": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsTopics": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueues": {
+                    "description": "whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesMessageCount": {
+                    "description": "the message count the queue must be at or below before it can be evaluated  to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "configDeleteAddresses": {
+                    "description": "What to do when an address is no longer in broker.xml. OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "configDeleteQueues": {
+                    "description": "What to do when a queue is no longer in broker.xml. OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "deadLetterAddress": {
+                    "description": "the address to send dead messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueuePrefix": {
+                    "description": "the prefix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueueSuffix": {
+                    "description": "the suffix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultAddressRoutingType": {
+                    "description": "the routing-type used on auto-created addresses",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultConsumerWindowSize": {
+                    "description": "the default window size for a consumer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultConsumersBeforeDispatch": {
+                    "description": "the default number of consumers needed before dispatch can start for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultDelayBeforeDispatch": {
+                    "description": "the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultExclusiveQueue": {
+                    "description": "whether to treat the queues under the address as exclusive queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupBuckets": {
+                    "description": "number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupFirstKey": {
+                    "description": "key used to mark a message is first in a group for a consumer",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalance": {
+                    "description": "whether to rebalance groups when a consumer is added",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalancePauseDispatch": {
+                    "description": "whether to pause dispatch when rebalancing groups",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueKey": {
+                    "description": "the property to use as the key for a last value queue by default",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueQueue": {
+                    "description": "whether to treat the queues under the address as a last value queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultMaxConsumers": {
+                    "description": "the maximum number of consumers allowed on this queue at any one time",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultNonDestructive": {
+                    "description": "whether the queue should be non-destructive by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultPurgeOnNoConsumers": {
+                    "description": "purge the contents of the queue once there are no consumers",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultQueueRoutingType": {
+                    "description": "the routing-type used on auto-created queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultRingSize": {
+                    "description": "the default ring-size value for any matching queue which doesnt have ring-size explicitly defined",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "enableIngressTimestamp": {
+                    "description": "whether or not set the timestamp of arrival on messages. default false",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enableMetrics": {
+                    "description": "whether or not to enable metrics for metrics plugins on the matching address",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiryAddress": {
+                    "description": "the address to send expired messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryDelay": {
+                    "description": "Overrides the expiration time for messages using the default value for expiration time. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "expiryQueuePrefix": {
+                    "description": "the prefix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryQueueSuffix": {
+                    "description": "the suffix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastValueQueue": {
+                    "description": "This is deprecated please use default-last-value-queue instead.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "managementBrowsePageSize": {
+                    "description": "how many message a management resource can browse",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "managementMessageAttributeSizeLimit": {
+                    "description": "max size of the message returned from management API, default 256",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "match": {
+                    "description": "pattern for matching settings against addresses; can use wildards",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxDeliveryAttempts": {
+                    "description": "how many times to attempt to deliver a message before sending to dead letter address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a higher value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxRedeliveryDelay": {
+                    "description": "Maximum value for the redelivery-delay",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytes": {
+                    "description": "the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytesRejectThreshold": {
+                    "description": "used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only. Default = -1 (no limit).",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "messageCounterHistoryDayLimit": {
+                    "description": "how many days to keep message counter history for this address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "minExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a lower value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageMaxCacheSize": {
+                    "description": "Number of paging files to cache in memory to avoid IO during paging navigation",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageSizeBytes": {
+                    "description": "The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "redeliveryCollisionAvoidanceFactor": {
+                    "description": "factor by which to modify the redelivery delay slightly to avoid collisions",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelay": {
+                    "description": "the time (in ms) to wait before redelivering a cancelled message.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelayMultiplier": {
+                    "description": "multiplier to apply to the redelivery-delay",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redistributionDelay": {
+                    "description": "how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "retroactiveMessageCount": {
+                    "description": "the number of messages to preserve for future queues created on the matching address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "sendToDlaOnNoRoute": {
+                    "description": "if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerCheckPeriod": {
+                    "description": "How often to check for slow consumers on a particular queue. Measured in seconds.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerPolicy": {
+                    "description": "what happens when a slow consumer is identified",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "KILL",
+                      "NOTIFY"
+                    ]
+                  },
+                  "slowConsumerThreshold": {
+                    "description": "The minimum rate of message consumption allowed before a consumer is considered \"slow.\" Measured in messages-per-second.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerThresholdMeasurementUnit": {
+                    "description": "unit used in specifying slow consumer threshold; available values: MESSAGES_PER_SECOND MESSAGES_PER_MINUTE MESSAGES_PER_HOUR MESSAGES_PER_DAY default is MESSAGE_PER_SECOND",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "MESSAGES_PER_SECOND",
+                      "MESSAGES_PER_MINUTE",
+                      "MESSAGES_PER_HOUR",
+                      "MESSAGES_PER_DAY"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "applyRule": {
+              "description": "a flag APPLY_RULE that indicates on what parts of address settings in broker.xml to perform the merge. It has 3 possible values: =replace_all The merge performs merge on the address-settings as a whole part. =merge_replace The merge performs merge on each address-setting element =merge_all The merge performs merge on each property of every address-setting This is the default value",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name does not match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "clustered": {
+              "description": "whether the broker deployments are clustered or not",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enableMetricsPlugin": {
+              "description": "whether or not to install the artemis metrics plugin",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "extraMounts": {
+              "description": "Optional configmaps and secrets as mount volumes",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "configMaps": {
+                  "description": "List of configmaps to mount",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "secrets": {
+                  "description": "List of secrets to mount",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "initImage": {
+              "description": "The init container image used to configure broker",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "jolokiaAgentEnabled": {
+              "description": "If true enable the Jolokia JVM Agent",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "livenessProbe": {
+              "description": "Optional broker container liveness probe configuration",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "timeoutSeconds": {
+                  "description": "timeoutSeconds for the probe. Default 5 seconds",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "managementRBACEnabled": {
+              "description": "If true enable the management role based access control",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "podSecurity": {
+              "description": "Security properties for broker pods",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "runAsUser": {
+                  "description": "runAsUser as defined in PodSecurityContext",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "serviceAccountName": {
+                  "description": "serviceAccount Name of the pod",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "readinessProbe": {
+              "description": "Optional broker container readiness probe configuration",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "timeoutSeconds": {
+                  "description": "timeoutSeconds for the probe. Default 5 seconds",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resources": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            },
+            "storage": {
+              "description": "the storage capacity",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "size": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha5"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisaddress-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisaddress-broker-v2alpha1.json
@@ -1,0 +1,67 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddress"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "addressName",
+        "queueName",
+        "routingType"
+      ],
+      "properties": {
+        "addressName": {
+          "type": "string"
+        },
+        "queueName": {
+          "type": "string"
+        },
+        "routingType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddress",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisaddress-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisaddress-broker-v2alpha2.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddress"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "addressName",
+        "queueName",
+        "routingType"
+      ],
+      "properties": {
+        "addressName": {
+          "type": "string"
+        },
+        "queueName": {
+          "type": "string"
+        },
+        "removeFromBrokerOnDelete": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "routingType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddress",
+      "version": "v2alpha2"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisaddress-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisaddress-broker-v2alpha3.json
@@ -1,0 +1,268 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddress"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "addressName"
+      ],
+      "properties": {
+        "addressName": {
+          "type": "string"
+        },
+        "applyToCrNames": {
+          "description": "Apply to the broker crs in the current namespace A value of * means applying to all broker crs. Default apply to all broker crs.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "password": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "queueConfiguration": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "autoCreateAddress": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "autoDelete": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "autoDeleteDelay": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "autoDeleteMessageCount": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "configurationManaged": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consumerPriority": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "consumersBeforeDispatch": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "delayBeforeDispatch": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "durable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "exclusive": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "filterString": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "groupBuckets": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "groupFirstKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "groupRebalance": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "groupRebalancePauseDispatch": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "ignoreIfExists": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "lastValue": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "lastValueKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "maxConsumers": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nonDestructive": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "purgeOnNoConsumers": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "ringSize": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "routingType": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "temporary": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "queueName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "removeFromBrokerOnDelete": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "routingType": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "user": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddress",
+      "version": "v2alpha3"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisaddresslist-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisaddresslist-broker-v2alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisAddressList is a list of ActiveMQArtemisAddress",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisaddresses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisAddress"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddressList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddressList",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisaddresslist-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisaddresslist-broker-v2alpha2.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisAddressList is a list of ActiveMQArtemisAddress",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisaddresses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisAddress"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddressList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddressList",
+      "version": "v2alpha2"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisaddresslist-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisaddresslist-broker-v2alpha3.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisAddressList is a list of ActiveMQArtemisAddress",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisaddresses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisAddress"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddressList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddressList",
+      "version": "v2alpha3"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha2.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha2"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha3.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha3"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha4.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha4.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha4"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha4.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha4"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha5.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemislist-broker-v2alpha5.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha5"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha5.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha5"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisscaledown-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisscaledown-broker-v2alpha1.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisScaledown"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "localOnly"
+      ],
+      "properties": {
+        "localOnly": {
+          "description": "If enabled, the controller only handles StatefulSets in a single namespace instead of across all namespaces.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisScaledown",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemisscaledownlist-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemisscaledownlist-broker-v2alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisScaledownList is a list of ActiveMQArtemisScaledown",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisscaledowns. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisScaledown"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisScaledownList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisScaledownList",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemissecurity-broker-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemissecurity-broker-v1alpha1.json
@@ -1,0 +1,924 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisSecurity"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "applyToCrNames": {
+          "description": "Apply to the broker crs in the current namespace A value of * means applying to all broker crs. Default apply to all broker crs.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "loginModules": {
+          "description": "the login modules",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "guestLoginModules": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "guestRole": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "guestUser": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "keycloakLoginModules": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "configuration": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowAnyHostName": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "alwaysRefreshToken": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "authServerUrl": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "autoDetectBearerOnly": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "bearerOnly": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientKeyPassword": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "clientKeyStore": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "clientKeyStorePassword": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "confidentialPort": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "connectionPoolSize": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "corsAllowedHeaders": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "corsAllowedMethods": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "corsExposedHeaders": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "corsMaxAge": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "credentials": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "value": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "disableTrustManager": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "enableBasicAuth": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "enableCors": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "exposeToken": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "ignoreOauthQueryParameter": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "minTimeBetweenJwksRequests": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "principalAttribute": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "proxyUrl": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "publicClient": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "publicKeyCacheTtl": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "realm": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "realmPublicKey": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "redirectRewriteRules": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "value": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "registerNodeAtStartup": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "registerNodePeriod": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "resource": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "scope": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "sslRequired": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tokenCookiePath": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tokenMinimumTimeToLive": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "tokenStore": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "trustStore": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "trustStorePassword": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "turnOffChangeSessionIdOnLogin": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "useResourceRoleMappings": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "verifyTokenAudience": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "moduleType": {
+                    "description": "one of directAccess or bearerToken",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "propertiesLoginModules": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "users": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "password": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "roles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "securityDomains": {
+          "description": "the security domains for the broker",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "brokerDomain": {
+              "description": "the broker domain config",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "loginModules": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "debug": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "flag": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "reload": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "consoleDomain": {
+              "description": "the console domain config",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "loginModules": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "debug": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "flag": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "reload": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "securitySettings": {
+          "description": "permission control configuration",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "broker": {
+              "description": "security settings in broker.xml",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "match": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "permissions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "operationType": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "roles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "management": {
+              "description": "management api access control",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "authorisation": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "allowedList": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "domain": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "key": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "defaultAccess": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "method": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "roles": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "roleAccess": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "accessList": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "method": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "roles": {
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "domain": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "key": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "connector": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "authenticatorType": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "host": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "jmxRealm": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "keyStorePassword": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "keyStorePath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "keyStoreProvider": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "objectName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "passwordCodec": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "port": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "rmiRegistryPort": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "secured": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "trustStorePassword": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "trustStorePath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "trustStoreProvider": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "hawtioRoles": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisSecurity",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/activemqartemissecuritylist-broker-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/activemqartemissecuritylist-broker-v1alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "ActiveMQArtemisSecurityList is a list of ActiveMQArtemisSecurity",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemissecurities. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v1alpha1.ActiveMQArtemisSecurity"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisSecurityList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisSecurityList",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/all.json
+++ b/openshift-json-schema/master-standalone-strict/all.json
@@ -754,6 +754,66 @@
       "$ref": "_definitions.json#/definitions/com.stakater.forecastle.v1alpha1.ForecastleAppList"
     },
     {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v1alpha1.ActiveMQArtemisSecurity"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v1alpha1.ActiveMQArtemisSecurityList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisAddress"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisAddressList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisScaledown"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisScaledownList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisAddress"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisAddressList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisAddress"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisAddressList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha4.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha4.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha5.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha5.ActiveMQArtemisList"
+    },
+    {
       "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.AppProject"
     },
     {
@@ -2951,6 +3011,48 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.redhat.redhatcop.v1alpha1.GroupSyncList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.Keycloak"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakRealmImport"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakRealmImportList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.Keycloak"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakBackup"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakBackupList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakClient"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakClientList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakRealm"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakRealmList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakUser"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakUserList"
     },
     {
       "$ref": "_definitions.json#/definitions/org.ovn.k8s.v1.EgressFirewall"

--- a/openshift-json-schema/master-standalone-strict/keycloak-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloak-k8s-v2alpha1.json
@@ -1,0 +1,7736 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "Keycloak"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "hostname",
+        "tlsSecret"
+      ],
+      "properties": {
+        "disableDefaultIngress": {
+          "description": "Disable the default ingress.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "hostname": {
+          "description": "Hostname for the Keycloak server.\nThe special value `INSECURE-DISABLE` disables the hostname strict resolution.",
+          "type": "string"
+        },
+        "image": {
+          "description": "Custom Keycloak image to be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "instances": {
+          "description": "Number of Keycloak instances in HA mode. Default is 1.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "serverConfiguration": {
+          "description": "Configuration of the Keycloak server.\nexpressed as a keys (reference: https://www.keycloak.org/server/all-config) and values that can be either direct values or references to secrets.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "secret": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "key": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "optional": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "tlsSecret": {
+          "description": "A secret containing the TLS configuration for HTTPS. Reference: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets.\nThe special value `INSECURE-DISABLE` disables https.",
+          "type": "string"
+        },
+        "unsupported": {
+          "description": "In this section you can configure podTemplate advanced features, not production-ready, and not supported settings.\nUse at your own risk and open an issue with your use-case if you don't find an alternative way.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "podTemplate": {
+              "description": "You can configure that will be merged with the one configured by default by the operator.\nUse at your own risk, we reserve the possibility to remove/change the way any field gets merged in future releases without notice.\nReference: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "metadata": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "annotations": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "clusterName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "creationTimestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "deletionTimestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "finalizers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "generateName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "generation": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "labels": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "managedFields": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "apiVersion": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "fieldsType": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "fieldsV1": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "manager": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "operation": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "subresource": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "time": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "namespace": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "ownerReferences": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "apiVersion": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "blockOwnerDeletion": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "controller": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "kind": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "uid": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "resourceVersion": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "selfLink": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "uid": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "affinity": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "nodeAffinity": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "preference": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchFields": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchFields": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "podAffinity": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "topologyKey": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "topologyKey": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "automountServiceAccountToken": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "containers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "args": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "value": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "envFrom": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "ports": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "hostIP": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "readinessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "runAsNonRoot": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "seLinuxOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "hostProcess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "volumeMounts": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "mountPropagation": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "readOnly": {
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "workingDir": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "dnsConfig": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "nameservers": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "options": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "value": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "searches": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "dnsPolicy": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "enableServiceLinks": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "ephemeralContainers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "args": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "value": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "envFrom": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "ports": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "hostIP": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "readinessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "runAsNonRoot": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "seLinuxOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "hostProcess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "targetContainerName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "volumeMounts": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "mountPropagation": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "readOnly": {
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "workingDir": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "hostAliases": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "hostnames": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "ip": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "hostIPC": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "hostNetwork": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "hostPID": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "hostname": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "imagePullSecrets": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "initContainers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "args": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "value": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "envFrom": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "ports": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "hostIP": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "readinessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "runAsNonRoot": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "seLinuxOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "hostProcess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "volumeMounts": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "mountPropagation": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "readOnly": {
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "workingDir": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "nodeName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "nodeSelector": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "os": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "overhead": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "preemptionPolicy": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "priority": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "priorityClassName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "readinessGates": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "conditionType": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "restartPolicy": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "runtimeClassName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "schedulerName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "securityContext": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "fsGroup": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "runAsGroup": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "runAsNonRoot": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "runAsUser": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "seLinuxOptions": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "level": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "role": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "user": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "localhostProfile": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "supplementalGroups": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          }
+                        },
+                        "sysctls": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "value": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "windowsOptions": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "hostProcess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "runAsUserName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "serviceAccount": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "serviceAccountName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "shareProcessNamespace": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "subdomain": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "tolerations": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "effect": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "key": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "operator": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tolerationSeconds": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "value": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "topologySpreadConstraints": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "matchExpressions": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "operator": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "values": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "matchLabels": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "maxSkew": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "topologyKey": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "whenUnsatisfiable": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "volumes": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "partition": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "azureDisk": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "cachingMode": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "diskName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "diskURI": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "kind": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "azureFile": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "shareName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "cephfs": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "monitors": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretFile": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "cinder": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "volumeID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "configMap": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "items": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    },
+                                    "path": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "optional": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "csi": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "driver": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "nodePublishSecretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeAttributes": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "downwardAPI": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "items": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    },
+                                    "path": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "emptyDir": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "medium": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "sizeLimit": {
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "ephemeral": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "metadata": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "annotations": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "clusterName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "creationTimestamp": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "finalizers": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "generateName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "generation": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      },
+                                      "labels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "managedFields": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "fieldsType": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "fieldsV1": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ]
+                                            },
+                                            "manager": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operation": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "subresource": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "time": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "namespace": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "ownerReferences": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": [
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "controller": {
+                                              "type": [
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "kind": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "uid": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "resourceVersion": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "selfLink": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "uid": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "spec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "accessModes": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "dataSource": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "kind": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "name": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "dataSourceRef": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "kind": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "name": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "resources": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "limits": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          },
+                                          "requests": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "selector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "storageClassName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "volumeMode": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "volumeName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "fc": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "lun": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "targetWWNs": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "wwids": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "flexVolume": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "driver": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "options": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "flocker": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "datasetName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "datasetUUID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "gcePersistentDisk": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "partition": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "pdName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "gitRepo": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "directory": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "repository": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "revision": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "glusterfs": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "endpoints": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "hostPath": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "iscsi": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "chapAuthSession": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "initiatorName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "iqn": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "iscsiInterface": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "lun": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "portals": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "targetPortal": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "nfs": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "server": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "persistentVolumeClaim": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "claimName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "photonPersistentDisk": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "pdID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "portworxVolume": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "projected": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "sources": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMap": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "mode": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "path": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "downwardAPI": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "properties": {
+                                              "fieldRef": {
+                                                "type": [
+                                                  "object",
+                                                  "null"
+                                                ],
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "additionalProperties": false
+                                              },
+                                              "mode": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "path": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "resourceFieldRef": {
+                                                "type": [
+                                                  "object",
+                                                  "null"
+                                                ],
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "divisor": {
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "secret": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "mode": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "path": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountToken": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "audience": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "expirationSeconds": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ]
+                                        },
+                                        "path": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "quobyte": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "group": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "registry": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "tenant": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "user": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volume": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "rbd": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "image": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "keyring": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "monitors": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "pool": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "scaleIO": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "gateway": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "protectionDomain": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "sslEnabled": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "storageMode": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePool": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "system": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumeName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "items": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    },
+                                    "path": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "optional": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "storageos": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "volumeName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumeNamespace": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "vsphereVolume": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePolicyID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePolicyName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumePath": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "conditions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "message": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "Keycloak",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloak-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloak-keycloak-v1alpha1.json
@@ -1,0 +1,1413 @@
+{
+  "description": "Keycloak is the Schema for the keycloaks API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "Keycloak"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakSpec defines the desired state of Keycloak.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "extensions": {
+          "description": "A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "x-kubernetes-list-type": "set"
+        },
+        "external": {
+          "description": "Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "url": {
+              "description": "The URL to use for the keycloak admin API. Needs to be set if external is true.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "externalAccess": {
+          "description": "Controls external Ingress/Route settings.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "host": {
+              "description": "If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tlsTermination": {
+              "description": "TLS Termination type for the external access. Setting this field to \"reencrypt\" will terminate TLS on the Ingress/Route level. Setting this field to \"passthrough\" will send encrypted traffic to the Pod. If unspecified, defaults to \"reencrypt\". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "externalDatabase": {
+          "description": "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "instances": {
+          "description": "Number of Keycloak instances in HA mode. Default is 1.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "keycloakDeploymentSpec": {
+          "description": "Resources (Requests and Limits) for KeycloakDeployment.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "experimental": {
+              "description": "Experimental section NOTE: This section might change or get removed without any notice. It may also cause the deployment to behave in an unpredictable fashion. Please use with care.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "affinity": {
+                  "description": "Affinity settings",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "nodeAffinity": {
+                      "description": "Describes node affinity scheduling rules for the pod.",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "A node selector term, associated with the corresponding weight.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                              "type": "array",
+                              "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "args": {
+                  "description": "Arguments to the entrypoint. Translates into Container CMD.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "command": {
+                  "description": "Container command. Translates into Container ENTRYPOINT.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "env": {
+                  "description": "List of environment variables to set in the container.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "resource"
+                            ],
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "divisor": {
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "serviceAccountName": {
+                  "description": "ServiceAccountName settings",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "volumes": {
+                  "description": "Additional volume mounts",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "defaultMode": {
+                      "description": "Permissions mode.",
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "format": "int32"
+                    },
+                    "items": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "mountPath"
+                        ],
+                        "properties": {
+                          "configMaps": {
+                            "description": "Allow multiple configmaps to mount to the same directory",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "items": {
+                            "description": "Mount details",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "The key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "mountPath": {
+                            "description": "An absolute path where to mount it",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Volume name",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "secrets": {
+                            "description": "Secret mount",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "podlabels": {
+              "description": "List of labels to set in the keycloak pods",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "resources": {
+              "description": "Resources (Requests and Limits) for the Pods.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "requests": {
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "migration": {
+          "description": "Specify Migration configuration",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "backups": {
+              "description": "Set it to config backup policy for migration",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "enabled": {
+                  "description": "If set to true, the operator will do database backup before doing migration",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "strategy": {
+              "description": "Specify migration strategy",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "multiAvailablityZones": {
+          "description": "Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "podDisruptionBudget": {
+          "description": "Specify PodDisruptionBudget configuration.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "postgresDeploymentSpec": {
+          "description": "Resources (Requests and Limits) for PostgresDeployment.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "resources": {
+              "description": "Resources (Requests and Limits) for the Pods.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "requests": {
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "profile": {
+          "description": "Profile used for controlling Operator behavior. Default is empty.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storageClassName": {
+          "description": "Name of the StorageClass for Postgresql Persistent Volume Claim",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unmanaged": {
+          "description": "When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KeycloakStatus defines the observed state of Keycloak.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "credentialSecret",
+        "internalURL",
+        "message",
+        "phase",
+        "ready",
+        "version"
+      ],
+      "properties": {
+        "credentialSecret": {
+          "description": "The secret where the admin credentials are to be found.",
+          "type": "string"
+        },
+        "externalURL": {
+          "description": "External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "internalURL": {
+          "description": "An internal URL (service name) to be used by the admin client.",
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ].",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "version": {
+          "description": "Version of Keycloak or RHSSO running on the cluster.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "Keycloak",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakbackup-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakbackup-keycloak-v1alpha1.json
@@ -1,0 +1,205 @@
+{
+  "description": "KeycloakBackup is the Schema for the keycloakbackups API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakBackup"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakBackupSpec defines the desired state of KeycloakBackup.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "aws": {
+          "description": "If provided, an automatic database backup will be created on AWS S3 instead of a local Persistent Volume. If this property is not provided - a local Persistent Volume backup will be chosen.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "credentialsSecretName": {
+              "description": "Provides a secret name used for connecting to AWS S3 Service. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information, please refer to the Operator documentation.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "encryptionKeySecretName": {
+              "description": "If provided, the database backup will be encrypted. Provides a secret name used for encrypting database data. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT: <GPG Recipient> \n For more information, please refer to the Operator documentation.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schedule": {
+              "description": "If specified, it will be used as a schedule for creating a CronJob.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "instanceSelector": {
+          "description": "Selector for looking up Keycloak Custom Resources.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "restore": {
+          "description": "Controls automatic restore behavior. Currently not implemented. \n In the future this will be used to trigger automatic restore for a given KeycloakBackup. Each backup will correspond to a single snapshot of the database (stored either in a Persistent Volume or AWS). If a user wants to restore it, all he/she needs to do is to change this flag to true. Potentially, it will be possible to restore a single backup multiple times.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "storageClassName": {
+          "description": "Name of the StorageClass for Postgresql Backup Persistent Volume Claim",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KeycloakBackupStatus defines the observed state of KeycloakBackup.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "message",
+        "phase",
+        "ready"
+      ],
+      "properties": {
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ]",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakBackup",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakbackuplist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakbackuplist-keycloak-v1alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "KeycloakBackupList is a list of KeycloakBackup",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakbackups. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakBackup"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakBackupList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakBackupList",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakclient-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakclient-keycloak-v1alpha1.json
@@ -1,0 +1,1670 @@
+{
+  "description": "KeycloakClient is the Schema for the keycloakclients API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakClient"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakClientSpec defines the desired state of KeycloakClient.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "client",
+        "realmSelector"
+      ],
+      "properties": {
+        "client": {
+          "description": "Keycloak Client REST object.",
+          "type": "object",
+          "required": [
+            "clientId"
+          ],
+          "properties": {
+            "access": {
+              "description": "Access options.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "adminUrl": {
+              "description": "Application Admin URL.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "attributes": {
+              "description": "Client Attributes.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "authenticationFlowBindingOverrides": {
+              "description": "Authentication Flow Binding Overrides.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "authorizationServicesEnabled": {
+              "description": "True if fine-grained authorization support is enabled for this client.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "authorizationSettings": {
+              "description": "Authorization settings for this resource server.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "allowRemoteResourceManagement": {
+                  "description": "True if resources should be managed remotely by the resource server.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "clientId": {
+                  "description": "Client ID.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "decisionStrategy": {
+                  "description": "The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "description": "ID.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "Name.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "policies": {
+                  "description": "Policies.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "config": {
+                        "description": "Config.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "decisionStrategy": {
+                        "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "description": "A description for this policy.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "logic": {
+                        "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "The name of this policy.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "owner": {
+                        "description": "Owner.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "description": "Policies.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "resources": {
+                        "description": "Resources.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "resourcesData": {
+                        "description": "Resources Data.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "description": "The attributes associated with the resource.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "displayName": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ownerManagedAccess": {
+                              "description": "True if the access to this resource can be managed by the resource owner.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "description": "The scopes associated with this resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "description": "Set of URIs which are protected by resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "scopes": {
+                        "description": "Scopes.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "scopesData": {
+                        "description": "Scopes Data.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "type": {
+                        "description": "Type.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "policyEnforcementMode": {
+                  "description": "The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "resources": {
+                  "description": "Resources.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "_id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "attributes": {
+                        "description": "The attributes associated with the resource.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "displayName": {
+                        "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "icon_uri": {
+                        "description": "An URI pointing to an icon.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "ownerManagedAccess": {
+                        "description": "True if the access to this resource can be managed by the resource owner.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "scopes": {
+                        "description": "The scopes associated with this resource.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "type": {
+                        "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "uris": {
+                        "description": "Set of URIs which are protected by resource.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "scopes": {
+                  "description": "Authorization Scopes.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "displayName": {
+                        "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "iconUri": {
+                        "description": "An URI pointing to an icon.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "description": "Policies.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "description": "Config.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "description": {
+                              "description": "A description for this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "The name of this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "description": "Owner.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "description": "Policies.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "description": "Resources.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "description": "Resources Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "description": "The attributes associated with the resource.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "displayName": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "description": "An URI pointing to an icon.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ownerManagedAccess": {
+                                    "description": "True if the access to this resource can be managed by the resource owner.",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "description": "The scopes associated with this resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "description": "Set of URIs which are protected by resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "scopes": {
+                              "description": "Scopes.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "description": "Scopes Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "Type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "resources": {
+                        "description": "Resources.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "description": "The attributes associated with the resource.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "displayName": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ownerManagedAccess": {
+                              "description": "True if the access to this resource can be managed by the resource owner.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "description": "The scopes associated with this resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "description": "Set of URIs which are protected by resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "baseUrl": {
+              "description": "Application base URL.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "bearerOnly": {
+              "description": "True if a client supports only Bearer Tokens.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "clientAuthenticatorType": {
+              "description": "What Client authentication type to use.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "clientId": {
+              "description": "Client ID.",
+              "type": "string"
+            },
+            "consentRequired": {
+              "description": "True if Consent Screen is required.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "defaultClientScopes": {
+              "description": "A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultRoles": {
+              "description": "Default Client roles.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "description": {
+              "description": "Client description.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "directAccessGrantsEnabled": {
+              "description": "True if Direct Grant is enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabled": {
+              "description": "Client enabled flag.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "frontchannelLogout": {
+              "description": "True if this client supports Front Channel logout.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fullScopeAllowed": {
+              "description": "True if Full Scope is allowed.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "id": {
+              "description": "Client ID. If not specified, automatically generated.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "implicitFlowEnabled": {
+              "description": "True if Implicit flow is enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "description": "Client name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "nodeReRegistrationTimeout": {
+              "description": "Node registration timeout.",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "notBefore": {
+              "description": "Not Before setting.",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "optionalClientScopes": {
+              "description": "A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "protocol": {
+              "description": "Protocol used for this Client.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protocolMappers": {
+              "description": "Protocol Mappers.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "description": "Config options.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "consentRequired": {
+                    "description": "True if Consent Screen is required.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "consentText": {
+                    "description": "Text to use for displaying Consent Screen.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "Protocol Mapper ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Protocol Mapper Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "description": "Protocol to use.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMapper": {
+                    "description": "Protocol Mapper to use",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "publicClient": {
+              "description": "True if this is a public Client.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "redirectUris": {
+              "description": "A list of valid Redirection URLs.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "rootUrl": {
+              "description": "Application root URL.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "secret": {
+              "description": "Client Secret. The Operator will automatically create a Secret based on this value.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "serviceAccountsEnabled": {
+              "description": "True if Service Accounts are enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "standardFlowEnabled": {
+              "description": "True if Standard flow is enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "surrogateAuthRequired": {
+              "description": "Surrogate Authentication Required option.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "useTemplateConfig": {
+              "description": "True to use a Template Config.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "useTemplateMappers": {
+              "description": "True to use Template Mappers.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "useTemplateScope": {
+              "description": "True to use Template Scope.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "webOrigins": {
+              "description": "A list of valid Web Origins.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "realmSelector": {
+          "description": "Selector for looking up KeycloakRealm Custom Resources.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "roles": {
+          "description": "Client Roles",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Role Attributes",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "clientRole": {
+                "description": "Client Role",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "composite": {
+                "description": "Composite",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "composites": {
+                "description": "Composites",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "description": "Map client => []role",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "realm": {
+                    "description": "Realm roles",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "containerId": {
+                "description": "Container Id",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "description": {
+                "description": "Description",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "id": {
+                "description": "Id",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "scopeMappings": {
+          "description": "Scope Mappings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "clientMappings": {
+              "description": "Client Mappings",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "description": "Client",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mappings": {
+                    "description": "Mappings",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Role Attributes",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "description": "Client Role",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "description": "Composite",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "description": "Composites",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "client": {
+                              "description": "Map client => []role",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "description": "Realm roles",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "containerId": {
+                          "description": "Container Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "description": "Description",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "realmMappings": {
+              "description": "Realm Mappings",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "attributes": {
+                    "description": "Role Attributes",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientRole": {
+                    "description": "Client Role",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "composite": {
+                    "description": "Composite",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "composites": {
+                    "description": "Composites",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "client": {
+                        "description": "Map client => []role",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "realm": {
+                        "description": "Realm roles",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "containerId": {
+                    "description": "Container Id",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "description": "Description",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "Id",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KeycloakClientStatus defines the observed state of KeycloakClient",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "message",
+        "phase",
+        "ready"
+      ],
+      "properties": {
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ]",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakClient",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakclientlist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakclientlist-keycloak-v1alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "KeycloakClientList is a list of KeycloakClient",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakclients. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakClient"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakClientList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakClientList",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloaklist-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloaklist-k8s-v2alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "KeycloakList is a list of Keycloak",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloaks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.Keycloak"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "KeycloakList",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloaklist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloaklist-keycloak-v1alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "KeycloakList is a list of Keycloak",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloaks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.Keycloak"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakList",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakrealm-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakrealm-keycloak-v1alpha1.json
@@ -1,0 +1,2838 @@
+{
+  "description": "KeycloakRealm is the Schema for the keycloakrealms API",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealm"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakRealmSpec defines the desired state of KeycloakRealm.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "realm"
+      ],
+      "properties": {
+        "instanceSelector": {
+          "description": "Selector for looking up Keycloak Custom Resources.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "realm": {
+          "description": "Keycloak Realm REST object.",
+          "type": "object",
+          "required": [
+            "realm"
+          ],
+          "properties": {
+            "accessTokenLifespan": {
+              "description": "Access Token Lifespan",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "accessTokenLifespanForImplicitFlow": {
+              "description": "Access Token Lifespan For Implicit Flow",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "accountTheme": {
+              "description": "Account Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "adminEventsDetailsEnabled": {
+              "description": "Enable admin events details TODO: change to values and use kubebuilder default annotation once supported",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminEventsEnabled": {
+              "description": "Enable events recording TODO: change to values and use kubebuilder default annotation once supported",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminTheme": {
+              "description": "Admin Console Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "authenticationFlows": {
+              "description": "Authentication flows",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "alias",
+                  "authenticationExecutions"
+                ],
+                "properties": {
+                  "alias": {
+                    "description": "Alias",
+                    "type": "string"
+                  },
+                  "authenticationExecutions": {
+                    "description": "Authentication executions",
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "authenticator": {
+                          "description": "Authenticator",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorConfig": {
+                          "description": "Authenticator Config",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorFlow": {
+                          "description": "Authenticator flow",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "flowAlias": {
+                          "description": "Flow Alias",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "description": "Priority",
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int32"
+                        },
+                        "requirement": {
+                          "description": "Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userSetupAllowed": {
+                          "description": "User setup allowed",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "builtIn": {
+                    "description": "Built in",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "description": "Description",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "description": "Provider ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "topLevel": {
+                    "description": "Top level",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "authenticatorConfig": {
+              "description": "Authenticator config",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "alias"
+                ],
+                "properties": {
+                  "alias": {
+                    "description": "Alias",
+                    "type": "string"
+                  },
+                  "config": {
+                    "description": "Config",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "description": "ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "bruteForceProtected": {
+              "description": "Brute Force Detection",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "clientScopeMappings": {
+              "description": "Client Scope Mappings",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "description": "Client",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientScope": {
+                      "description": "Client Scope",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "roles": {
+                      "description": "Roles",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "self": {
+                      "description": "Self",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "clientScopes": {
+              "description": "Client scopes",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "description": "Protocol Mappers.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "description": "Config options.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "description": "True if Consent Screen is required.",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "description": "Text to use for displaying Consent Screen.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Protocol Mapper ID.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Protocol Mapper Name.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "description": "Protocol to use.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "description": "Protocol Mapper to use",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "clients": {
+              "description": "A set of Keycloak Clients.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "clientId"
+                ],
+                "properties": {
+                  "access": {
+                    "description": "Access options.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "description": "Application Admin URL.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "description": "Client Attributes.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "description": "Authentication Flow Binding Overrides.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "description": "True if fine-grained authorization support is enabled for this client.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "description": "Authorization settings for this resource server.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "description": "True if resources should be managed remotely by the resource server.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "description": "Client ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "description": "The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "Name.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "description": "Policies.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "description": "Config.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "description": {
+                              "description": "A description for this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "The name of this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "description": "Owner.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "description": "Policies.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "description": "Resources.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "description": "Resources Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "description": "The attributes associated with the resource.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "displayName": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "description": "An URI pointing to an icon.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ownerManagedAccess": {
+                                    "description": "True if the access to this resource can be managed by the resource owner.",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "description": "The scopes associated with this resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "description": "Set of URIs which are protected by resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "scopes": {
+                              "description": "Scopes.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "description": "Scopes Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "Type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "description": "The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "resources": {
+                        "description": "Resources.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "description": "The attributes associated with the resource.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "displayName": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ownerManagedAccess": {
+                              "description": "True if the access to this resource can be managed by the resource owner.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "description": "The scopes associated with this resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "description": "Set of URIs which are protected by resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "scopes": {
+                        "description": "Authorization Scopes.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "description": "Policies.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "config": {
+                                    "description": "Config.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "decisionStrategy": {
+                                    "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "description": {
+                                    "description": "A description for this policy.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "logic": {
+                                    "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "The name of this policy.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "description": "Owner.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "policies": {
+                                    "description": "Policies.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "Resources.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "resourcesData": {
+                                    "description": "Resources Data.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "_id": {
+                                          "description": "ID.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "attributes": {
+                                          "description": "The attributes associated with the resource.",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "additionalProperties": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        },
+                                        "displayName": {
+                                          "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "icon_uri": {
+                                          "description": "An URI pointing to an icon.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "ownerManagedAccess": {
+                                          "description": "True if the access to this resource can be managed by the resource owner.",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "scopes": {
+                                          "description": "The scopes associated with this resource.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          }
+                                        },
+                                        "type": {
+                                          "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "uris": {
+                                          "description": "Set of URIs which are protected by resource.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "scopes": {
+                                    "description": "Scopes.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "scopesData": {
+                                    "description": "Scopes Data.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "Type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "resources": {
+                              "description": "Resources.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "description": "The attributes associated with the resource.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "displayName": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "description": "An URI pointing to an icon.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ownerManagedAccess": {
+                                    "description": "True if the access to this resource can be managed by the resource owner.",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "description": "The scopes associated with this resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "description": "Set of URIs which are protected by resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "baseUrl": {
+                    "description": "Application base URL.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "description": "True if a client supports only Bearer Tokens.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "clientAuthenticatorType": {
+                    "description": "What Client authentication type to use.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "description": "Client ID.",
+                    "type": "string"
+                  },
+                  "consentRequired": {
+                    "description": "True if Consent Screen is required.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "description": "A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "description": "Default Client roles.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "description": "Client description.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "description": "True if Direct Grant is enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "description": "Client enabled flag.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "description": "True if this client supports Front Channel logout.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "description": "True if Full Scope is allowed.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "Client ID. If not specified, automatically generated.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "description": "True if Implicit flow is enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Client name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "description": "Node registration timeout.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "description": "Not Before setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "description": "A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "protocol": {
+                    "description": "Protocol used for this Client.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "description": "Protocol Mappers.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "description": "Config options.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "description": "True if Consent Screen is required.",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "description": "Text to use for displaying Consent Screen.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Protocol Mapper ID.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Protocol Mapper Name.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "description": "Protocol to use.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "description": "Protocol Mapper to use",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "publicClient": {
+                    "description": "True if this is a public Client.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "description": "A list of valid Redirection URLs.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "rootUrl": {
+                    "description": "Application root URL.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "description": "Client Secret. The Operator will automatically create a Secret based on this value.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "description": "True if Service Accounts are enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "description": "True if Standard flow is enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "description": "Surrogate Authentication Required option.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "description": "True to use a Template Config.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "description": "True to use Template Mappers.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "description": "True to use Template Scope.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "description": "A list of valid Web Origins.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "defaultLocale": {
+              "description": "Default Locale",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "defaultRole": {
+              "description": "Default role",
+              "type": [
+                "object",
+                "null"
+              ],
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "attributes": {
+                  "description": "Role Attributes",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "clientRole": {
+                  "description": "Client Role",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composite": {
+                  "description": "Composite",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composites": {
+                  "description": "Composites",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "description": "Map client => []role",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "realm": {
+                      "description": "Realm roles",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "containerId": {
+                  "description": "Container Id",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "description": {
+                  "description": "Description",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "description": "Id",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "Name",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "displayName": {
+              "description": "Realm display name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "displayNameHtml": {
+              "description": "Realm HTML display name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "duplicateEmailsAllowed": {
+              "description": "Duplicate emails",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "editUsernameAllowed": {
+              "description": "Edit username",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "emailTheme": {
+              "description": "Email Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enabled": {
+              "description": "Realm enabled flag.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabledEventTypes": {
+              "description": "Enabled event types",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "eventsEnabled": {
+              "description": "Enable events recording TODO: change to values and use kubebuilder default annotation once supported",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "eventsListeners": {
+              "description": "A set of Event Listeners.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "failureFactor": {
+              "description": "Max Login Failures",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identityProviders": {
+              "description": "A set of Identity Providers.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addReadTokenRoleOnCreate": {
+                    "description": "Adds Read Token role when creating this Identity Provider.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "alias": {
+                    "description": "Identity Provider Alias.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "description": "Identity Provider config.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "description": "Identity Provider Display Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "description": "Identity Provider enabled flag.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "firstBrokerLoginFlowAlias": {
+                    "description": "Identity Provider First Broker Login Flow Alias.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "internalId": {
+                    "description": "Identity Provider Internal ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "linkOnly": {
+                    "description": "Identity Provider Link Only setting.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "postBrokerLoginFlowAlias": {
+                    "description": "Identity Provider Post Broker Login Flow Alias.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "description": "Identity Provider ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "storeToken": {
+                    "description": "Identity Provider Store to Token.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "trustEmail": {
+                    "description": "Identity Provider Trust Email.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "internationalizationEnabled": {
+              "description": "Internationalization Enabled",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "loginTheme": {
+              "description": "Login Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loginWithEmailAllowed": {
+              "description": "Login with email",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "maxDeltaTimeSeconds": {
+              "description": "Failure Reset Time",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "maxFailureWaitSeconds": {
+              "description": "Max Wait",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "minimumQuickLoginWaitSeconds": {
+              "description": "Minimum Quick Login Wait",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "passwordPolicy": {
+              "description": "Realm Password Policy",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "permanentLockout": {
+              "description": "Permanent Lockout",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "quickLoginCheckMilliSeconds": {
+              "description": "Quick Login Check Milli Seconds",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "realm": {
+              "description": "Realm name.",
+              "type": "string"
+            },
+            "registrationAllowed": {
+              "description": "User registration",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "registrationEmailAsUsername": {
+              "description": "Email as username",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "rememberMe": {
+              "description": "Remember me",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resetPasswordAllowed": {
+              "description": "Forgot password",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "roles": {
+              "description": "Roles",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "client": {
+                  "description": "Client Roles",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Role Attributes",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "description": "Client Role",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "description": "Composite",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "description": "Composites",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "client": {
+                              "description": "Map client => []role",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "description": "Realm roles",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "containerId": {
+                          "description": "Container Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "description": "Description",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "realm": {
+                  "description": "Realm Roles",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "description": "Role Attributes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "clientRole": {
+                        "description": "Client Role",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composite": {
+                        "description": "Composite",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composites": {
+                        "description": "Composites",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "client": {
+                            "description": "Map client => []role",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "realm": {
+                            "description": "Realm roles",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "containerId": {
+                        "description": "Container Id",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "description": "Description",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "Id",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "Name",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "scopeMappings": {
+              "description": "Scope Mappings",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "description": "Client",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientScope": {
+                    "description": "Client Scope",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "roles": {
+                    "description": "Roles",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "description": "Self",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "smtpServer": {
+              "description": "Email",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "sslRequired": {
+              "description": "Require SSL",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supportedLocales": {
+              "description": "Supported Locales",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "userFederationMappers": {
+              "description": "User federation mappers are extension points triggered by the user federation at various points.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "description": "User federation mapper config.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "federationMapperType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "federationProviderDisplayName": {
+                    "description": "The displayName for the user federation provider this mapper applies to.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "userFederationProviders": {
+              "description": "Point keycloak to an external user provider to validate credentials or pull in identity information.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "description": "User federation provider config.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "description": "The display name of this provider instance.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fullSyncPeriod": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int32"
+                  },
+                  "id": {
+                    "description": "The ID of this provider",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "priority": {
+                    "description": "The priority of this provider when looking up users or adding a user.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int32"
+                  },
+                  "providerName": {
+                    "description": "The name of the user provider, such as \"ldap\", \"kerberos\" or a custom SPI.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "userManagedAccessAllowed": {
+              "description": "User Managed Access Allowed",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "users": {
+              "description": "A set of Keycloak Users.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "description": "A set of Attributes.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientRoles": {
+                    "description": "A set of Client Roles.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "description": "A set of Credentials.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "temporary": {
+                          "description": "True if this credential object is temporary.",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "description": "Credential Type.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "value": {
+                          "description": "Credential Value.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "email": {
+                    "description": "Email.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "description": "True if email has already been verified.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "description": "User enabled flag.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "federatedIdentities": {
+                    "description": "A set of Federated Identities.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "identityProvider": {
+                          "description": "Federated Identity Provider.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userId": {
+                          "description": "Federated Identity User ID.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userName": {
+                          "description": "Federated Identity User Name.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "firstName": {
+                    "description": "First Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "groups": {
+                    "description": "A set of Groups.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "description": "User ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastName": {
+                    "description": "Last Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "description": "A set of Realm Roles.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "requiredActions": {
+                    "description": "A set of Required Actions.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "username": {
+                    "description": "User Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "verifyEmail": {
+              "description": "Verify email",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "waitIncrementSeconds": {
+              "description": "Wait Increment",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "realmOverrides": {
+          "description": "A list of overrides to the default Realm behavior.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "identityProvider"
+            ],
+            "properties": {
+              "forFlow": {
+                "description": "Flow to be overridden.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "identityProvider": {
+                "description": "Identity Provider to be overridden.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "x-kubernetes-list-type": "atomic"
+        },
+        "unmanaged": {
+          "description": "When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KeycloakRealmStatus defines the observed state of KeycloakRealm",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "loginURL",
+        "message",
+        "phase",
+        "ready"
+      ],
+      "properties": {
+        "loginURL": {
+          "description": "TODO",
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ]",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakRealm",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakrealmimport-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakrealmimport-k8s-v2alpha1.json
@@ -1,0 +1,6566 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealmImport"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "keycloakCRName",
+        "realm"
+      ],
+      "properties": {
+        "keycloakCRName": {
+          "description": "The name of the Keycloak CR to reference, in the same namespace.",
+          "type": "string"
+        },
+        "realm": {
+          "description": "The RealmRepresentation to import into Keycloak.",
+          "type": "object",
+          "properties": {
+            "accessCodeLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessCodeLifespanLogin": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessCodeLifespanUserAction": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessTokenLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessTokenLifespanForImplicitFlow": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accountTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "actionTokenGeneratedByAdminLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "actionTokenGeneratedByUserLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "adminEventsDetailsEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminEventsEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "applicationScopeMappings": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientScope": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientTemplate": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "roles": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "self": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "applications": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alwaysDisplayInConsole": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "AFFIRMATIVE",
+                          "CONSENSUS",
+                          "UNANIMOUS"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "AFFIRMATIVE",
+                                "CONSENSUS",
+                                "UNANIMOUS"
+                              ]
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "POSITIVE",
+                                "NEGATIVE"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "id": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "ownerManagedAccess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "displayName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "iconUri": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "id": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "PERMISSIVE",
+                          "ENFORCING",
+                          "DISABLED"
+                        ]
+                      },
+                      "resources": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "ownerManagedAccess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "scopes": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "baseUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "claims": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "address": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "email": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "gender": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "locale": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "phone": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "picture": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "profile": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "username": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "website": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "clientAuthenticatorType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "directGrantsOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "oauth2DeviceAuthorizationGrantEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registeredNodes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registrationAccessToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rootUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "attributes": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "authenticationFlows": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "authenticationExecutions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "authenticator": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorConfig": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorFlow": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "autheticatorFlow": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "flowAlias": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "requirement": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userSetupAllowed": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "builtIn": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "topLevel": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "authenticatorConfig": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "browserFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "browserSecurityHeaders": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "bruteForceProtected": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "certificate": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "clientAuthenticationFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "clientOfflineSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientOfflineSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientPolicies": {
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "clientProfiles": {
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "clientScopeMappings": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientScope": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientTemplate": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "roles": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "self": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "clientScopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "clientSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientTemplates": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "clients": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alwaysDisplayInConsole": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "AFFIRMATIVE",
+                          "CONSENSUS",
+                          "UNANIMOUS"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "AFFIRMATIVE",
+                                "CONSENSUS",
+                                "UNANIMOUS"
+                              ]
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "POSITIVE",
+                                "NEGATIVE"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "id": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "ownerManagedAccess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "displayName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "iconUri": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "id": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "PERMISSIVE",
+                          "ENFORCING",
+                          "DISABLED"
+                        ]
+                      },
+                      "resources": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "ownerManagedAccess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "scopes": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "baseUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "clientAuthenticatorType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "directGrantsOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "oauth2DeviceAuthorizationGrantEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registeredNodes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registrationAccessToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rootUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "codeSecret": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "components": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "config": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "providerId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "subComponents": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "providerId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "subType": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "subType": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "defaultDefaultClientScopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultGroups": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultLocale": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "defaultOptionalClientScopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultRole": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "attributes": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "clientRole": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composite": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composites": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "application": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "client": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "realm": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "containerId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "scopeParamRequired": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "defaultRoles": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultSignatureAlgorithm": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "directGrantFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "displayName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "displayNameHtml": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "dockerAuthenticationFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "duplicateEmailsAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "editUsernameAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "emailTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabledEventTypes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "eventsEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "eventsExpiration": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "eventsListeners": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "failureFactor": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "federatedUsers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "applicationRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientConsents": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "clientId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "grantedClientScopes": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "grantedRealmRoles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "lastUpdatedDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "clientRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "createdTimestamp": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "credentials": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "algorithm": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "counter": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "credentialData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "device": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "digits": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashIterations": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashedSaltedValue": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "period": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "salt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "secretData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "temporary": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userLabel": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "value": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "disableableCredentialTypes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "email": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "federatedIdentities": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "identityProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "federationLink": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "firstName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "groups": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "requiredActions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountClientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "socialLinks": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "socialProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUserId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUsername": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "totp": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "username": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "groups": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "path": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "subGroups": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "access": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
+                        },
+                        "attributes": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRoles": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "path": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "realmRoles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identityProviderMappers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "identityProviderAlias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "identityProviderMapper": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "identityProviders": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addReadTokenRoleOnCreate": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "authenticateByDefault": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "firstBrokerLoginFlowAlias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "internalId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "linkOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "postBrokerLoginFlowAlias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "storeToken": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "trustEmail": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "updateProfileFirstLoginMode": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "internationalizationEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "keycloakVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loginTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loginWithEmailAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "maxDeltaTimeSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "maxFailureWaitSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minimumQuickLoginWaitSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "notBefore": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "oauth2DeviceCodeLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "oauth2DevicePollingInterval": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "oauthClients": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alwaysDisplayInConsole": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "AFFIRMATIVE",
+                          "CONSENSUS",
+                          "UNANIMOUS"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "AFFIRMATIVE",
+                                "CONSENSUS",
+                                "UNANIMOUS"
+                              ]
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "POSITIVE",
+                                "NEGATIVE"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "id": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "ownerManagedAccess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "displayName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "iconUri": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "id": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "PERMISSIVE",
+                          "ENFORCING",
+                          "DISABLED"
+                        ]
+                      },
+                      "resources": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "ownerManagedAccess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "scopes": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "baseUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "claims": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "address": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "email": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "gender": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "locale": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "phone": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "picture": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "profile": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "username": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "website": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "clientAuthenticatorType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "directGrantsOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "oauth2DeviceAuthorizationGrantEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registeredNodes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registrationAccessToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rootUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "offlineSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "offlineSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "offlineSessionMaxLifespanEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "otpPolicyAlgorithm": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "otpPolicyDigits": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyInitialCounter": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyLookAheadWindow": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyPeriod": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyType": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "otpSupportedApplications": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "passwordCredentialGrantAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "passwordPolicy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "permanentLockout": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "privateKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protocolMappers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "consentText": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMapper": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "publicKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "quickLoginCheckMilliSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "realm": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "realmCacheEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "refreshTokenMaxReuse": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "registrationAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "registrationEmailAsUsername": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "registrationFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "rememberMe": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requiredActions": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultAction": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "priority": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "requiredCredentials": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "resetCredentialsFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resetPasswordAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "revokeRefreshToken": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "roles": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "application": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "application": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "client": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "containerId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "scopeParamRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "client": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "application": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "client": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "containerId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "scopeParamRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "realm": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "clientRole": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composite": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composites": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "application": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "client": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "realm": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "containerId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "scopeParamRequired": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "scopeMappings": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientScope": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "roles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "smtpServer": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "social": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "socialProviders": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "sslRequired": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ssoSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ssoSessionIdleTimeoutRememberMe": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ssoSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ssoSessionMaxLifespanRememberMe": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "supportedLocales": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "updateProfileOnInitialSocialLogin": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "userCacheEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "userFederationMappers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "federationMapperType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "federationProviderDisplayName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "userFederationProviders": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "changedSyncPeriod": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fullSyncPeriod": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastSync": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "priority": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "providerName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "userManagedAccessAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "users": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "applicationRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientConsents": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "clientId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "grantedClientScopes": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "grantedRealmRoles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "lastUpdatedDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "clientRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "createdTimestamp": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "credentials": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "algorithm": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "counter": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "credentialData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "device": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "digits": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashIterations": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashedSaltedValue": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "period": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "salt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "secretData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "temporary": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userLabel": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "value": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "disableableCredentialTypes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "email": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "federatedIdentities": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "identityProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "federationLink": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "firstName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "groups": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "requiredActions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountClientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "socialLinks": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "socialProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUserId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUsername": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "totp": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "username": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "verifyEmail": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "waitIncrementSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "webAuthnPolicyAcceptableAaguids": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyAttestationConveyancePreference": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyAuthenticatorAttachment": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "webAuthnPolicyCreateTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessAcceptableAaguids": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessCreateTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessRequireResidentKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessRpEntityName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessRpId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyRequireResidentKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyRpEntityName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyRpId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicySignatureAlgorithms": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyUserVerificationRequirement": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "conditions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "message": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "KeycloakRealmImport",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakrealmimportlist-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakrealmimportlist-k8s-v2alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "KeycloakRealmImportList is a list of KeycloakRealmImport",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakrealmimports. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakRealmImport"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealmImportList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "KeycloakRealmImportList",
+      "version": "v2alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakrealmlist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakrealmlist-keycloak-v1alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "KeycloakRealmList is a list of KeycloakRealm",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakrealms. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakRealm"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealmList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakRealmList",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakuser-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakuser-keycloak-v1alpha1.json
@@ -1,0 +1,346 @@
+{
+  "description": "KeycloakUser is the Schema for the keycloakusers API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakUser"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakUserSpec defines the desired state of KeycloakUser.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "user"
+      ],
+      "properties": {
+        "realmSelector": {
+          "description": "Selector for looking up KeycloakRealm Custom Resources.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "user": {
+          "description": "Keycloak User REST object.",
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "description": "A set of Attributes.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "clientRoles": {
+              "description": "A set of Client Roles.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "credentials": {
+              "description": "A set of Credentials.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "temporary": {
+                    "description": "True if this credential object is temporary.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "description": "Credential Type.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "value": {
+                    "description": "Credential Value.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "email": {
+              "description": "Email.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "emailVerified": {
+              "description": "True if email has already been verified.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabled": {
+              "description": "User enabled flag.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "federatedIdentities": {
+              "description": "A set of Federated Identities.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "identityProvider": {
+                    "description": "Federated Identity Provider.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "userId": {
+                    "description": "Federated Identity User ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "userName": {
+                    "description": "Federated Identity User Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "firstName": {
+              "description": "First Name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "groups": {
+              "description": "A set of Groups.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "id": {
+              "description": "User ID.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lastName": {
+              "description": "Last Name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "realmRoles": {
+              "description": "A set of Realm Roles.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "requiredActions": {
+              "description": "A set of Required Actions.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "username": {
+              "description": "User Name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KeycloakUserStatus defines the observed state of KeycloakUser.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "message",
+        "phase"
+      ],
+      "properties": {
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakUser",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone-strict/keycloakuserlist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone-strict/keycloakuserlist-keycloak-v1alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "KeycloakUserList is a list of KeycloakUser",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakusers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakUser"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakUserList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakUserList",
+      "version": "v1alpha1"
+    }
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha1.json
@@ -1,0 +1,447 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha2.json
@@ -1,0 +1,477 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            }
+          }
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha2"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha3.json
@@ -1,0 +1,1038 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "amqpMinLargeMessageSize": {
+                "description": "The default value is 102400 (100KBytes). Setting it to -1 will disable large message support.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "addressSettings": {
+          "description": "a list of address settings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "addressSetting": {
+              "description": "address setting configuration",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addressFullPolicy": {
+                    "description": "what happens when an address where maxSizeBytes is specified becomes full",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "DROP",
+                      "FAIL",
+                      "PAGE",
+                      "BLOCK"
+                    ]
+                  },
+                  "autoCreateAddresses": {
+                    "description": "whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateDeadLetterResources": {
+                    "description": "whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateExpiryResources": {
+                    "description": "whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsQueues": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsTopics": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateQueues": {
+                    "description": "whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddresses": {
+                    "description": "whether or not to delete auto-created addresses when it no longer has any queues",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddressesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteCreatedQueues": {
+                    "description": "whether or not to delete created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsQueues": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsTopics": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueues": {
+                    "description": "whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesMessageCount": {
+                    "description": "the message count the queue must be at or below before it can be evaluated  to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "configDeleteAddresses": {
+                    "description": "What to do when an address is no longer in broker.xml. OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "configDeleteQueues": {
+                    "description": "What to do when a queue is no longer in broker.xml. OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "deadLetterAddress": {
+                    "description": "the address to send dead messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueuePrefix": {
+                    "description": "the prefix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueueSuffix": {
+                    "description": "the suffix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultAddressRoutingType": {
+                    "description": "the routing-type used on auto-created addresses",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultConsumerWindowSize": {
+                    "description": "the default window size for a consumer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultConsumersBeforeDispatch": {
+                    "description": "the default number of consumers needed before dispatch can start for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultDelayBeforeDispatch": {
+                    "description": "the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultExclusiveQueue": {
+                    "description": "whether to treat the queues under the address as exclusive queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupBuckets": {
+                    "description": "number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupFirstKey": {
+                    "description": "key used to mark a message is first in a group for a consumer",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalance": {
+                    "description": "whether to rebalance groups when a consumer is added",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalancePauseDispatch": {
+                    "description": "whether to pause dispatch when rebalancing groups",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueKey": {
+                    "description": "the property to use as the key for a last value queue by default",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueQueue": {
+                    "description": "whether to treat the queues under the address as a last value queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultMaxConsumers": {
+                    "description": "the maximum number of consumers allowed on this queue at any one time",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultNonDestructive": {
+                    "description": "whether the queue should be non-destructive by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultPurgeOnNoConsumers": {
+                    "description": "purge the contents of the queue once there are no consumers",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultQueueRoutingType": {
+                    "description": "the routing-type used on auto-created queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultRingSize": {
+                    "description": "the default ring-size value for any matching queue which doesnt have ring-size explicitly defined",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "enableMetrics": {
+                    "description": "whether or not to enable metrics for metrics plugins on the matching address",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiryAddress": {
+                    "description": "the address to send expired messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryDelay": {
+                    "description": "Overrides the expiration time for messages using the default value for expiration time. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "expiryQueuePrefix": {
+                    "description": "the prefix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryQueueSuffix": {
+                    "description": "the suffix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastValueQueue": {
+                    "description": "This is deprecated please use default-last-value-queue instead.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "managementBrowsePageSize": {
+                    "description": "how many message a management resource can browse",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "match": {
+                    "description": "pattern for matching settings against addresses; can use wildards",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxDeliveryAttempts": {
+                    "description": "how many times to attempt to deliver a message before sending to dead letter address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a higher value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxRedeliveryDelay": {
+                    "description": "Maximum value for the redelivery-delay",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytes": {
+                    "description": "the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytesRejectThreshold": {
+                    "description": "used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only. Default = -1 (no limit).",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "messageCounterHistoryDayLimit": {
+                    "description": "how many days to keep message counter history for this address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "minExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a lower value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageMaxCacheSize": {
+                    "description": "Number of paging files to cache in memory to avoid IO during paging navigation",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageSizeBytes": {
+                    "description": "The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "redeliveryCollisionAvoidanceFactor": {
+                    "description": "factor by which to modify the redelivery delay slightly to avoid collisions",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelay": {
+                    "description": "the time (in ms) to wait before redelivering a cancelled message.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelayMultiplier": {
+                    "description": "multiplier to apply to the redelivery-delay",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redistributionDelay": {
+                    "description": "how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "retroactiveMessageCount": {
+                    "description": "the number of messages to preserve for future queues created on the matching address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "sendToDlaOnNoRoute": {
+                    "description": "if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerCheckPeriod": {
+                    "description": "How often to check for slow consumers on a particular queue. Measured in seconds.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerPolicy": {
+                    "description": "what happens when a slow consumer is identified",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "KILL",
+                      "NOTIFY"
+                    ]
+                  },
+                  "slowConsumerThreshold": {
+                    "description": "The minimum rate of message consumption allowed before a consumer is considered \"slow.\" Measured in messages-per-second.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "applyRule": {
+              "description": "a flag APPLY_RULE that indicates on what parts of address settings in broker.xml to perform the merge. It has 3 possible values: =replace_all The merge performs merge on the address-settings as a whole part. =merge_replace The merge performs merge on each address-setting element =merge_all The merge performs merge on each property of every address-setting This is the default value",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resources": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "requests": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            },
+            "storage": {
+              "description": "the storage capacity",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "size": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha3"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha4.json
+++ b/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha4.json
@@ -1,0 +1,1059 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha4"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "amqpMinLargeMessageSize": {
+                "description": "The default value is 102400 (100KBytes). Setting it to -1 will disable large message support.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "addressSettings": {
+          "description": "a list of address settings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "addressSetting": {
+              "description": "address setting configuration",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addressFullPolicy": {
+                    "description": "what happens when an address where maxSizeBytes is specified becomes full",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "DROP",
+                      "FAIL",
+                      "PAGE",
+                      "BLOCK"
+                    ]
+                  },
+                  "autoCreateAddresses": {
+                    "description": "whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateDeadLetterResources": {
+                    "description": "whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateExpiryResources": {
+                    "description": "whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsQueues": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsTopics": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateQueues": {
+                    "description": "whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddresses": {
+                    "description": "whether or not to delete auto-created addresses when it no longer has any queues",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddressesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteCreatedQueues": {
+                    "description": "whether or not to delete created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsQueues": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsTopics": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueues": {
+                    "description": "whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesMessageCount": {
+                    "description": "the message count the queue must be at or below before it can be evaluated  to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "configDeleteAddresses": {
+                    "description": "What to do when an address is no longer in broker.xml. OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "configDeleteQueues": {
+                    "description": "What to do when a queue is no longer in broker.xml. OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "deadLetterAddress": {
+                    "description": "the address to send dead messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueuePrefix": {
+                    "description": "the prefix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueueSuffix": {
+                    "description": "the suffix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultAddressRoutingType": {
+                    "description": "the routing-type used on auto-created addresses",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultConsumerWindowSize": {
+                    "description": "the default window size for a consumer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultConsumersBeforeDispatch": {
+                    "description": "the default number of consumers needed before dispatch can start for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultDelayBeforeDispatch": {
+                    "description": "the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultExclusiveQueue": {
+                    "description": "whether to treat the queues under the address as exclusive queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupBuckets": {
+                    "description": "number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupFirstKey": {
+                    "description": "key used to mark a message is first in a group for a consumer",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalance": {
+                    "description": "whether to rebalance groups when a consumer is added",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalancePauseDispatch": {
+                    "description": "whether to pause dispatch when rebalancing groups",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueKey": {
+                    "description": "the property to use as the key for a last value queue by default",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueQueue": {
+                    "description": "whether to treat the queues under the address as a last value queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultMaxConsumers": {
+                    "description": "the maximum number of consumers allowed on this queue at any one time",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultNonDestructive": {
+                    "description": "whether the queue should be non-destructive by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultPurgeOnNoConsumers": {
+                    "description": "purge the contents of the queue once there are no consumers",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultQueueRoutingType": {
+                    "description": "the routing-type used on auto-created queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultRingSize": {
+                    "description": "the default ring-size value for any matching queue which doesnt have ring-size explicitly defined",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "enableMetrics": {
+                    "description": "whether or not to enable metrics for metrics plugins on the matching address",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiryAddress": {
+                    "description": "the address to send expired messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryDelay": {
+                    "description": "Overrides the expiration time for messages using the default value for expiration time. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "expiryQueuePrefix": {
+                    "description": "the prefix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryQueueSuffix": {
+                    "description": "the suffix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastValueQueue": {
+                    "description": "This is deprecated please use default-last-value-queue instead.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "managementBrowsePageSize": {
+                    "description": "how many message a management resource can browse",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "match": {
+                    "description": "pattern for matching settings against addresses; can use wildards",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxDeliveryAttempts": {
+                    "description": "how many times to attempt to deliver a message before sending to dead letter address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a higher value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxRedeliveryDelay": {
+                    "description": "Maximum value for the redelivery-delay",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytes": {
+                    "description": "the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytesRejectThreshold": {
+                    "description": "used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only. Default = -1 (no limit).",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "messageCounterHistoryDayLimit": {
+                    "description": "how many days to keep message counter history for this address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "minExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a lower value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageMaxCacheSize": {
+                    "description": "Number of paging files to cache in memory to avoid IO during paging navigation",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageSizeBytes": {
+                    "description": "The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "redeliveryCollisionAvoidanceFactor": {
+                    "description": "factor by which to modify the redelivery delay slightly to avoid collisions",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelay": {
+                    "description": "the time (in ms) to wait before redelivering a cancelled message.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelayMultiplier": {
+                    "description": "multiplier to apply to the redelivery-delay",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redistributionDelay": {
+                    "description": "how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "retroactiveMessageCount": {
+                    "description": "the number of messages to preserve for future queues created on the matching address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "sendToDlaOnNoRoute": {
+                    "description": "if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerCheckPeriod": {
+                    "description": "How often to check for slow consumers on a particular queue. Measured in seconds.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerPolicy": {
+                    "description": "what happens when a slow consumer is identified",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "KILL",
+                      "NOTIFY"
+                    ]
+                  },
+                  "slowConsumerThreshold": {
+                    "description": "The minimum rate of message consumption allowed before a consumer is considered \"slow.\" Measured in messages-per-second.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "applyRule": {
+              "description": "a flag APPLY_RULE that indicates on what parts of address settings in broker.xml to perform the merge. It has 3 possible values: =replace_all The merge performs merge on the address-settings as a whole part. =merge_replace The merge performs merge on each address-setting element =merge_all The merge performs merge on each property of every address-setting This is the default value",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name doesn't match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "initImage": {
+              "description": "The init container image used to configure broker addresssettings",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "jolokiaAgentEnabled": {
+              "description": "If true enable the Jolokia JVM Agent",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "managementRBACEnabled": {
+              "description": "If true enable the management role based access control",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resources": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "requests": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            },
+            "storage": {
+              "description": "the storage capacity",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "size": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha4"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha5.json
+++ b/openshift-json-schema/master-standalone/activemqartemis-broker-v2alpha5.json
@@ -1,0 +1,1204 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha5"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemis"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "acceptors": {
+          "description": "Configuration of all acceptors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single acceptor configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "amqpMinLargeMessageSize": {
+                "description": "The default value is 102400 (100KBytes). Setting it to -1 will disable large message support.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "anycastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "connectionsAllowed": {
+                "description": "Limits the number of connections which the acceptor will allow. When this limit is reached a DEBUG level message is issued to the log, and the connection is refused.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this acceptor",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "multicastPrefix": {
+                "description": "To indicate which kind of routing type to use.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "protocols": {
+                "description": "The protocols to enable for this acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name does not match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "supportAdvisory": {
+                "description": "For openwire protocol if advisory topics are enabled, default false",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "suppressInternalManagementObjects": {
+                "description": "If prevents advisory addresses/queues to be registered to management service, default false",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting clients SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "addressSettings": {
+          "description": "a list of address settings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "addressSetting": {
+              "description": "address setting configuration",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addressFullPolicy": {
+                    "description": "what happens when an address where maxSizeBytes is specified becomes full",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "DROP",
+                      "FAIL",
+                      "PAGE",
+                      "BLOCK"
+                    ]
+                  },
+                  "autoCreateAddresses": {
+                    "description": "whether or not to automatically create addresses when a client sends a message to or attempts to consume a message from a queue mapped to an address that doesnt exist",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateDeadLetterResources": {
+                    "description": "whether or not to automatically create the dead-letter-address and/or a corresponding queue on that address when a message found to be undeliverable",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateExpiryResources": {
+                    "description": "whether or not to automatically create the expiry-address and/or a corresponding queue on that address when a message is sent to a matching queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsQueues": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS queues when a producer sends or a consumer connects to a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateJmsTopics": {
+                    "description": "DEPRECATED. whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to a topic",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoCreateQueues": {
+                    "description": "whether or not to automatically create a queue when a client sends a message to or attempts to consume a message from a queue",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddresses": {
+                    "description": "whether or not to delete auto-created addresses when it no longer has any queues",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteAddressesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created addresses after they no longer have any queues",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteCreatedQueues": {
+                    "description": "whether or not to delete created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsQueues": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteJmsTopics": {
+                    "description": "DEPRECATED. whether or not to delete auto-created JMS topics when the last subscription is closed",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueues": {
+                    "description": "whether or not to delete auto-created queues when the queue has 0 consumers and 0 messages",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesDelay": {
+                    "description": "how long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "autoDeleteQueuesMessageCount": {
+                    "description": "the message count the queue must be at or below before it can be evaluated  to be auto deleted, 0 waits until empty queue (default) and -1 disables this check.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "configDeleteAddresses": {
+                    "description": "What to do when an address is no longer in broker.xml. OFF = will do nothing addresses will remain, FORCE = delete address and its queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "configDeleteQueues": {
+                    "description": "What to do when a queue is no longer in broker.xml. OFF = will do nothing queues will remain, FORCE = delete queues even if messages remaining.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "OFF",
+                      "FORCE"
+                    ]
+                  },
+                  "deadLetterAddress": {
+                    "description": "the address to send dead messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueuePrefix": {
+                    "description": "the prefix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "deadLetterQueueSuffix": {
+                    "description": "the suffix to use for auto-created dead letter queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultAddressRoutingType": {
+                    "description": "the routing-type used on auto-created addresses",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultConsumerWindowSize": {
+                    "description": "the default window size for a consumer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultConsumersBeforeDispatch": {
+                    "description": "the default number of consumers needed before dispatch can start for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultDelayBeforeDispatch": {
+                    "description": "the default delay (in milliseconds) to wait before dispatching if number of consumers before dispatch is not met for queues under the address.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultExclusiveQueue": {
+                    "description": "whether to treat the queues under the address as exclusive queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupBuckets": {
+                    "description": "number of buckets to use for grouping, -1 (default) is unlimited and uses the raw group, 0 disables message groups.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupFirstKey": {
+                    "description": "key used to mark a message is first in a group for a consumer",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalance": {
+                    "description": "whether to rebalance groups when a consumer is added",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultGroupRebalancePauseDispatch": {
+                    "description": "whether to pause dispatch when rebalancing groups",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueKey": {
+                    "description": "the property to use as the key for a last value queue by default",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultLastValueQueue": {
+                    "description": "whether to treat the queues under the address as a last value queues by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultMaxConsumers": {
+                    "description": "the maximum number of consumers allowed on this queue at any one time",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "defaultNonDestructive": {
+                    "description": "whether the queue should be non-destructive by default",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultPurgeOnNoConsumers": {
+                    "description": "purge the contents of the queue once there are no consumers",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultQueueRoutingType": {
+                    "description": "the routing-type used on auto-created queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "ANYCAST",
+                      "MULTICAST"
+                    ]
+                  },
+                  "defaultRingSize": {
+                    "description": "the default ring-size value for any matching queue which doesnt have ring-size explicitly defined",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "enableIngressTimestamp": {
+                    "description": "whether or not set the timestamp of arrival on messages. default false",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enableMetrics": {
+                    "description": "whether or not to enable metrics for metrics plugins on the matching address",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "expiryAddress": {
+                    "description": "the address to send expired messages to",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryDelay": {
+                    "description": "Overrides the expiration time for messages using the default value for expiration time. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "expiryQueuePrefix": {
+                    "description": "the prefix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expiryQueueSuffix": {
+                    "description": "the suffix to use for auto-created expiry queues",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastValueQueue": {
+                    "description": "This is deprecated please use default-last-value-queue instead.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "managementBrowsePageSize": {
+                    "description": "how many message a management resource can browse",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "managementMessageAttributeSizeLimit": {
+                    "description": "max size of the message returned from management API, default 256",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "match": {
+                    "description": "pattern for matching settings against addresses; can use wildards",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxDeliveryAttempts": {
+                    "description": "how many times to attempt to deliver a message before sending to dead letter address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a higher value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxRedeliveryDelay": {
+                    "description": "Maximum value for the redelivery-delay",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytes": {
+                    "description": "the maximum size in bytes for an address. -1 means no limits. This is used in PAGING, BLOCK and FAIL policies. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxSizeBytesRejectThreshold": {
+                    "description": "used with the address full BLOCK policy, the maximum size in bytes an address can reach before messages start getting rejected. Works in combination with max-size-bytes for AMQP protocol only. Default = -1 (no limit).",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "messageCounterHistoryDayLimit": {
+                    "description": "how many days to keep message counter history for this address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "minExpiryDelay": {
+                    "description": "Overrides the expiration time for messages using a lower value. \"-1\" disables this setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageMaxCacheSize": {
+                    "description": "Number of paging files to cache in memory to avoid IO during paging navigation",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pageSizeBytes": {
+                    "description": "The page size in bytes to use for an address. Supports byte notation like K, Mb, GB, etc.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "redeliveryCollisionAvoidanceFactor": {
+                    "description": "factor by which to modify the redelivery delay slightly to avoid collisions",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelay": {
+                    "description": "the time (in ms) to wait before redelivering a cancelled message.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "redeliveryDelayMultiplier": {
+                    "description": "multiplier to apply to the redelivery-delay",
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "redistributionDelay": {
+                    "description": "how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "retroactiveMessageCount": {
+                    "description": "the number of messages to preserve for future queues created on the matching address",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "sendToDlaOnNoRoute": {
+                    "description": "if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerCheckPeriod": {
+                    "description": "How often to check for slow consumers on a particular queue. Measured in seconds.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerPolicy": {
+                    "description": "what happens when a slow consumer is identified",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "KILL",
+                      "NOTIFY"
+                    ]
+                  },
+                  "slowConsumerThreshold": {
+                    "description": "The minimum rate of message consumption allowed before a consumer is considered \"slow.\" Measured in messages-per-second.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "slowConsumerThresholdMeasurementUnit": {
+                    "description": "unit used in specifying slow consumer threshold; available values: MESSAGES_PER_SECOND MESSAGES_PER_MINUTE MESSAGES_PER_HOUR MESSAGES_PER_DAY default is MESSAGE_PER_SECOND",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "MESSAGES_PER_SECOND",
+                      "MESSAGES_PER_MINUTE",
+                      "MESSAGES_PER_HOUR",
+                      "MESSAGES_PER_DAY"
+                    ]
+                  }
+                }
+              }
+            },
+            "applyRule": {
+              "description": "a flag APPLY_RULE that indicates on what parts of address settings in broker.xml to perform the merge. It has 3 possible values: =replace_all The merge performs merge on the address-settings as a whole part. =merge_replace The merge performs merge on each address-setting element =merge_all The merge performs merge on each property of every address-setting This is the default value",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "adminPassword": {
+          "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "adminUser": {
+          "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectors": {
+          "description": "Configuration of all connectors",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "description": "A single connector configuration",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "enabledCipherSuites": {
+                "description": "Comma separated list of cipher suites used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "enabledProtocols": {
+                "description": "Comma separated list of protocols used for SSL communication.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expose": {
+                "description": "Whether or not to expose this connector",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "host": {
+                "description": "Hostname or IP to connect to",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "The name of the acceptor",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "needClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is required. This property takes precedence over wantClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "port": {
+                "description": "Port number",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "sniHost": {
+                "description": "A regular expression used to match the server_name extension on incoming SSL connections. If the name does not match then the connection to the acceptor will be rejected.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslEnabled": {
+                "description": "Whether or not to enable SSL on this port",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "sslProvider": {
+                "description": "Used to change the SSL Provider between JDK and OPENSSL. The default is JDK.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sslSecret": {
+                "description": "Name of the secret to use for ssl information",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type either tcp or vm",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifyHost": {
+                "description": "The CN of the connecting client's SSL certificate will be compared to its hostname to verify they match. This is useful only for 2-way SSL.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "wantClientAuth": {
+                "description": "Tells a client connecting to this acceptor that 2-way SSL is requested but not required. Overridden by needClientAuth.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "console": {
+          "description": "Configuration for the embedded web console",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "expose": {
+              "description": "Whether or not to expose this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslEnabled": {
+              "description": "Whether or not to enable SSL on this port",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "sslSecret": {
+              "description": "Name of the secret to use for ssl information",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "useClientAuth": {
+              "description": "If the embedded server requires client authentication",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "deploymentPlan": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "clustered": {
+              "description": "whether the broker deployments are clustered or not",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enableMetricsPlugin": {
+              "description": "whether or not to install the artemis metrics plugin",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "extraMounts": {
+              "description": "Optional configmaps and secrets as mount volumes",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "configMaps": {
+                  "description": "List of configmaps to mount",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "secrets": {
+                  "description": "List of secrets to mount",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "image": {
+              "description": "The image used for the broker deployment",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "initImage": {
+              "description": "The init container image used to configure broker",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "jolokiaAgentEnabled": {
+              "description": "If true enable the Jolokia JVM Agent",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "journalType": {
+              "description": "If aio use ASYNCIO, if nio use NIO for journal IO",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "livenessProbe": {
+              "description": "Optional broker container liveness probe configuration",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "timeoutSeconds": {
+                  "description": "timeoutSeconds for the probe. Default 5 seconds",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "managementRBACEnabled": {
+              "description": "If true enable the management role based access control",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "messageMigration": {
+              "description": "If true migrate messages on scaledown",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "persistenceEnabled": {
+              "description": "If true use persistent volume via persistent volume claim for journal storage",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "podSecurity": {
+              "description": "Security properties for broker pods",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "runAsUser": {
+                  "description": "runAsUser as defined in PodSecurityContext",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "serviceAccountName": {
+                  "description": "serviceAccount Name of the pod",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "readinessProbe": {
+              "description": "Optional broker container readiness probe configuration",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "timeoutSeconds": {
+                  "description": "timeoutSeconds for the probe. Default 5 seconds",
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "requireLogin": {
+              "description": "If true require user password login credentials for broker protocol ports",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resources": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "requests": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "cpu": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "size": {
+              "description": "The number of broker pods to deploy",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 16,
+              "minimum": 0
+            },
+            "storage": {
+              "description": "the storage capacity",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "size": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "upgrades": {
+          "description": "Specify the level of upgrade that should be allowed when an older product version is detected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "Set true to enable automatic micro version product upgrades, it is disabled by default.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "minor": {
+              "description": "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "version": {
+          "description": "The version of the application deployment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "podStatus"
+      ],
+      "properties": {
+        "podStatus": {
+          "type": "object",
+          "properties": {
+            "ready": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "starting": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "stopped": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemis",
+      "version": "v2alpha5"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisaddress-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemisaddress-broker-v2alpha1.json
@@ -1,0 +1,65 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddress"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "addressName",
+        "queueName",
+        "routingType"
+      ],
+      "properties": {
+        "addressName": {
+          "type": "string"
+        },
+        "queueName": {
+          "type": "string"
+        },
+        "routingType": {
+          "type": "string"
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddress",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisaddress-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone/activemqartemisaddress-broker-v2alpha2.json
@@ -1,0 +1,71 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddress"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "addressName",
+        "queueName",
+        "routingType"
+      ],
+      "properties": {
+        "addressName": {
+          "type": "string"
+        },
+        "queueName": {
+          "type": "string"
+        },
+        "removeFromBrokerOnDelete": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "routingType": {
+          "type": "string"
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddress",
+      "version": "v2alpha2"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisaddress-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone/activemqartemisaddress-broker-v2alpha3.json
@@ -1,0 +1,265 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddress"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "addressName"
+      ],
+      "properties": {
+        "addressName": {
+          "type": "string"
+        },
+        "applyToCrNames": {
+          "description": "Apply to the broker crs in the current namespace A value of * means applying to all broker crs. Default apply to all broker crs.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "password": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "queueConfiguration": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "autoCreateAddress": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "autoDelete": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "autoDeleteDelay": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "autoDeleteMessageCount": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "configurationManaged": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "consumerPriority": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "consumersBeforeDispatch": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "delayBeforeDispatch": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "durable": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "exclusive": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "filterString": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "groupBuckets": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "groupFirstKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "groupRebalance": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "groupRebalancePauseDispatch": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "ignoreIfExists": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "lastValue": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "lastValueKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "maxConsumers": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "nonDestructive": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "purgeOnNoConsumers": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "ringSize": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "routingType": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "temporary": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "queueName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "removeFromBrokerOnDelete": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "routingType": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "user": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddress",
+      "version": "v2alpha3"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisaddresslist-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemisaddresslist-broker-v2alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisAddressList is a list of ActiveMQArtemisAddress",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisaddresses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisAddress"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddressList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddressList",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisaddresslist-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone/activemqartemisaddresslist-broker-v2alpha2.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisAddressList is a list of ActiveMQArtemisAddress",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisaddresses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisAddress"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddressList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddressList",
+      "version": "v2alpha2"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisaddresslist-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone/activemqartemisaddresslist-broker-v2alpha3.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisAddressList is a list of ActiveMQArtemisAddress",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisaddresses. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisAddress"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisAddressList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisAddressList",
+      "version": "v2alpha3"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha2.json
+++ b/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha2.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha2"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha2"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha3.json
+++ b/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha3.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha3"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha3"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha4.json
+++ b/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha4.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha4"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha4.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha4"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha5.json
+++ b/openshift-json-schema/master-standalone/activemqartemislist-broker-v2alpha5.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisList is a list of ActiveMQArtemis",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha5"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemises. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha5.ActiveMQArtemis"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisList",
+      "version": "v2alpha5"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisscaledown-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemisscaledown-broker-v2alpha1.json
@@ -1,0 +1,58 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisScaledown"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "localOnly"
+      ],
+      "properties": {
+        "localOnly": {
+          "description": "If enabled, the controller only handles StatefulSets in a single namespace instead of across all namespaces.",
+          "type": "boolean"
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisScaledown",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemisscaledownlist-broker-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemisscaledownlist-broker-v2alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisScaledownList is a list of ActiveMQArtemisScaledown",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemisscaledowns. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisScaledown"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisScaledownList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisScaledownList",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/activemqartemissecurity-broker-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemissecurity-broker-v1alpha1.json
@@ -1,0 +1,899 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisSecurity"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "applyToCrNames": {
+          "description": "Apply to the broker crs in the current namespace A value of * means applying to all broker crs. Default apply to all broker crs.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 0,
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "loginModules": {
+          "description": "the login modules",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "guestLoginModules": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "guestRole": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "guestUser": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "keycloakLoginModules": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "configuration": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowAnyHostName": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "alwaysRefreshToken": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "authServerUrl": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "autoDetectBearerOnly": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "bearerOnly": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientKeyPassword": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "clientKeyStore": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "clientKeyStorePassword": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "confidentialPort": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "connectionPoolSize": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "corsAllowedHeaders": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "corsAllowedMethods": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "corsExposedHeaders": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "corsMaxAge": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "credentials": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "value": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "disableTrustManager": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "enableBasicAuth": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "enableCors": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "exposeToken": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "ignoreOauthQueryParameter": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "minTimeBetweenJwksRequests": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "principalAttribute": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "proxyUrl": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "publicClient": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "publicKeyCacheTtl": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "realm": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "realmPublicKey": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "redirectRewriteRules": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "value": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "registerNodeAtStartup": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "registerNodePeriod": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "resource": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "scope": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "sslRequired": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tokenCookiePath": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "tokenMinimumTimeToLive": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "tokenStore": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "trustStore": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "trustStorePassword": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "turnOffChangeSessionIdOnLogin": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "useResourceRoleMappings": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "verifyTokenAudience": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "moduleType": {
+                    "description": "one of directAccess or bearerToken",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "propertiesLoginModules": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "users": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "password": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "roles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "securityDomains": {
+          "description": "the security domains for the broker",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "brokerDomain": {
+              "description": "the broker domain config",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "loginModules": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "debug": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "flag": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "reload": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "consoleDomain": {
+              "description": "the console domain config",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "loginModules": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "debug": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "flag": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "reload": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "securitySettings": {
+          "description": "permission control configuration",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "broker": {
+              "description": "security settings in broker.xml",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "match": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "permissions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "operationType": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "roles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "management": {
+              "description": "management api access control",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "authorisation": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "allowedList": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "domain": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "key": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "defaultAccess": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "method": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "roles": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "roleAccess": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "accessList": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "method": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "roles": {
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "domain": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "key": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "connector": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "authenticatorType": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "host": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "jmxRealm": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "keyStorePassword": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "keyStorePath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "keyStoreProvider": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "objectName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "passwordCodec": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "port": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "rmiRegistryPort": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "secured": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "trustStorePassword": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "trustStorePath": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "trustStoreProvider": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "hawtioRoles": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisSecurity",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/activemqartemissecuritylist-broker-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/activemqartemissecuritylist-broker-v1alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "ActiveMQArtemisSecurityList is a list of ActiveMQArtemisSecurity",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "broker.amq.io/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of activemqartemissecurities. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.amq.broker.v1alpha1.ActiveMQArtemisSecurity"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ActiveMQArtemisSecurityList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "broker.amq.io",
+      "kind": "ActiveMQArtemisSecurityList",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/all.json
+++ b/openshift-json-schema/master-standalone/all.json
@@ -754,6 +754,66 @@
       "$ref": "_definitions.json#/definitions/com.stakater.forecastle.v1alpha1.ForecastleAppList"
     },
     {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v1alpha1.ActiveMQArtemisSecurity"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v1alpha1.ActiveMQArtemisSecurityList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisAddress"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisAddressList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisScaledown"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha1.ActiveMQArtemisScaledownList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisAddress"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisAddressList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha2.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisAddress"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisAddressList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha3.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha4.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha4.ActiveMQArtemisList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha5.ActiveMQArtemis"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.amq.broker.v2alpha5.ActiveMQArtemisList"
+    },
+    {
       "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.AppProject"
     },
     {
@@ -2951,6 +3011,48 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.redhat.redhatcop.v1alpha1.GroupSyncList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.Keycloak"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakRealmImport"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakRealmImportList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.Keycloak"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakBackup"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakBackupList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakClient"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakClientList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakRealm"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakRealmList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakUser"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakUserList"
     },
     {
       "$ref": "_definitions.json#/definitions/org.ovn.k8s.v1.EgressFirewall"

--- a/openshift-json-schema/master-standalone/deploymentcondition-apps-v1.json
+++ b/openshift-json-schema/master-standalone/deploymentcondition-apps-v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "DeploymentCondition describes the state of a deployment config at a certain point.",
+  "description": "DeploymentCondition describes the state of a deployment at a certain point.",
   "type": "object",
   "required": [
     "type",
@@ -7,7 +7,7 @@
   ],
   "properties": {
     "lastTransitionTime": {
-      "description": "The last time the condition transitioned from one status to another.",
+      "description": "Last time the condition transitioned from one status to another.",
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
     },
     "lastUpdateTime": {

--- a/openshift-json-schema/master-standalone/deploymentstrategy-apps-v1.json
+++ b/openshift-json-schema/master-standalone/deploymentstrategy-apps-v1.json
@@ -1,59 +1,13 @@
 {
-  "description": "DeploymentStrategy describes how to perform a deployment.",
+  "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
   "type": "object",
   "properties": {
-    "activeDeadlineSeconds": {
-      "description": "ActiveDeadlineSeconds is the duration in seconds that the deployer pods for this deployment config may be active on a node before the system actively tries to terminate them.",
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "int64"
-    },
-    "annotations": {
-      "description": "Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.",
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": {
-        "type": [
-          "string",
-          "null"
-        ]
-      }
-    },
-    "customParams": {
-      "description": "CustomParams are the input to the Custom deployment strategy, and may also be specified for the Recreate and Rolling strategies to customize the execution process that runs the deployment.",
-      "$ref": "_definitions.json#/definitions/com.github.openshift.api.apps.v1.CustomDeploymentStrategyParams"
-    },
-    "labels": {
-      "description": "Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.",
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": {
-        "type": [
-          "string",
-          "null"
-        ]
-      }
-    },
-    "recreateParams": {
-      "description": "RecreateParams are the input to the Recreate deployment strategy.",
-      "$ref": "_definitions.json#/definitions/com.github.openshift.api.apps.v1.RecreateDeploymentStrategyParams"
-    },
-    "resources": {
-      "description": "Resources contains resource requirements to execute the deployment and any hooks.",
-      "$ref": "_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-    },
-    "rollingParams": {
-      "description": "RollingParams are the input to the Rolling deployment strategy.",
-      "$ref": "_definitions.json#/definitions/com.github.openshift.api.apps.v1.RollingDeploymentStrategyParams"
+    "rollingUpdate": {
+      "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
+      "$ref": "_definitions.json#/definitions/io.k8s.api.apps.v1.RollingUpdateDeployment"
     },
     "type": {
-      "description": "Type is the name of a deployment strategy.",
+      "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
       "type": [
         "string",
         "null"

--- a/openshift-json-schema/master-standalone/keycloak-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloak-k8s-v2alpha1.json
@@ -1,0 +1,7468 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "Keycloak"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "hostname",
+        "tlsSecret"
+      ],
+      "properties": {
+        "disableDefaultIngress": {
+          "description": "Disable the default ingress.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "hostname": {
+          "description": "Hostname for the Keycloak server.\nThe special value `INSECURE-DISABLE` disables the hostname strict resolution.",
+          "type": "string"
+        },
+        "image": {
+          "description": "Custom Keycloak image to be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "instances": {
+          "description": "Number of Keycloak instances in HA mode. Default is 1.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "serverConfiguration": {
+          "description": "Configuration of the Keycloak server.\nexpressed as a keys (reference: https://www.keycloak.org/server/all-config) and values that can be either direct values or references to secrets.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "secret": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "key": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "optional": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "tlsSecret": {
+          "description": "A secret containing the TLS configuration for HTTPS. Reference: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets.\nThe special value `INSECURE-DISABLE` disables https.",
+          "type": "string"
+        },
+        "unsupported": {
+          "description": "In this section you can configure podTemplate advanced features, not production-ready, and not supported settings.\nUse at your own risk and open an issue with your use-case if you don't find an alternative way.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "podTemplate": {
+              "description": "You can configure that will be merged with the one configured by default by the operator.\nUse at your own risk, we reserve the possibility to remove/change the way any field gets merged in future releases without notice.\nReference: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "metadata": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "annotations": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "clusterName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "creationTimestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "deletionTimestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "finalizers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "generateName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "generation": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "labels": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "managedFields": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "apiVersion": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "fieldsType": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "fieldsV1": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "manager": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "operation": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "subresource": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "time": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "namespace": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "ownerReferences": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "apiVersion": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "blockOwnerDeletion": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "controller": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "kind": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "uid": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "resourceVersion": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "selfLink": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "uid": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "spec": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "affinity": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "nodeAffinity": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "preference": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchFields": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchFields": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "podAffinity": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "namespaceSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "namespaces": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "topologyKey": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaceSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaces": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "podAntiAffinity": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "namespaceSelector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "namespaces": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "topologyKey": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaceSelector": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "values": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaces": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "automountServiceAccountToken": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "containers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "args": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "value": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "secretKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "envFrom": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "prefix": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "preStop": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "livenessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "ports": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "hostIP": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "readinessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "resources": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          },
+                          "securityContext": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "privileged": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "runAsNonRoot": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "seLinuxOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "seccompProfile": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "windowsOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "hostProcess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "startupProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "stdin": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "volumeMounts": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "mountPropagation": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "readOnly": {
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "workingDir": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "dnsConfig": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "nameservers": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "options": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "value": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "searches": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "dnsPolicy": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "enableServiceLinks": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "ephemeralContainers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "args": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "value": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "secretKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "envFrom": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "prefix": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "preStop": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "livenessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "ports": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "hostIP": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "readinessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "resources": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          },
+                          "securityContext": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "privileged": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "runAsNonRoot": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "seLinuxOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "seccompProfile": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "windowsOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "hostProcess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "startupProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "stdin": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "targetContainerName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "volumeMounts": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "mountPropagation": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "readOnly": {
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "workingDir": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "hostAliases": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "hostnames": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "ip": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "hostIPC": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "hostNetwork": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "hostPID": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "hostname": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "imagePullSecrets": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "initContainers": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "args": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "command": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "env": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "value": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "valueFrom": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "secretKeyRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "envFrom": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "configMapRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "prefix": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "secretRef": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "optional": {
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "imagePullPolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lifecycle": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "postStart": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "preStop": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "exec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "httpGet": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "httpHeaders": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "value": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "tcpSocket": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "host": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "port": {
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "livenessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "ports": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "containerPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "hostIP": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "hostPort": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "protocol": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "readinessProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "resources": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "limits": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          },
+                          "securityContext": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "capabilities": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "add": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "drop": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "privileged": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "procMount": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsGroup": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "runAsNonRoot": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "runAsUser": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "seLinuxOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "level": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "role": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "user": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "seccompProfile": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "windowsOptions": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "hostProcess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "runAsUserName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "startupProbe": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "exec": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "command": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "failureThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "grpc": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "port": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "service": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "httpHeaders": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "initialDelaySeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "periodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "successThreshold": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "tcpSocket": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "host": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "port": {
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "timeoutSeconds": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "stdin": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "stdinOnce": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePath": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "terminationMessagePolicy": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tty": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "volumeDevices": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "devicePath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "volumeMounts": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "mountPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "mountPropagation": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "readOnly": {
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "subPath": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "subPathExpr": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "workingDir": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "nodeName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "nodeSelector": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "os": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "overhead": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "preemptionPolicy": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "priority": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "priorityClassName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "readinessGates": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "conditionType": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "restartPolicy": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "runtimeClassName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "schedulerName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "securityContext": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "fsGroup": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "runAsGroup": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "runAsNonRoot": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "runAsUser": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "seLinuxOptions": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "level": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "role": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "user": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "seccompProfile": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "localhostProfile": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "supplementalGroups": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          }
+                        },
+                        "sysctls": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "value": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "windowsOptions": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "hostProcess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "runAsUserName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "serviceAccount": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "serviceAccountName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "shareProcessNamespace": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "subdomain": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "tolerations": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "effect": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "key": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "operator": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "tolerationSeconds": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "value": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "topologySpreadConstraints": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "matchExpressions": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "operator": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "values": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "matchLabels": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "maxSkew": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "topologyKey": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "whenUnsatisfiable": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "volumes": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "partition": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "azureDisk": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "cachingMode": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "diskName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "diskURI": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "kind": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "azureFile": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "shareName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "cephfs": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "monitors": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretFile": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "user": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "cinder": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "volumeID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "configMap": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "items": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    },
+                                    "path": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "optional": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "csi": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "driver": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "nodePublishSecretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeAttributes": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "downwardAPI": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "items": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "fieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "fieldPath": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "mode": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    },
+                                    "path": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "resourceFieldRef": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "containerName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "divisor": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "emptyDir": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "medium": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "sizeLimit": {
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          },
+                          "ephemeral": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "metadata": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "annotations": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "clusterName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "creationTimestamp": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "finalizers": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "generateName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "generation": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      },
+                                      "labels": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "managedFields": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "fieldsType": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "fieldsV1": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ]
+                                            },
+                                            "manager": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "operation": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "subresource": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "time": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "namespace": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "ownerReferences": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": [
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "controller": {
+                                              "type": [
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "kind": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "name": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "uid": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "resourceVersion": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "selfLink": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "uid": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "spec": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "accessModes": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "dataSource": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "kind": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "name": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "dataSourceRef": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "kind": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "name": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "resources": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "limits": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          },
+                                          "requests": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "selector": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "type": [
+                                              "array",
+                                              "null"
+                                            ],
+                                            "items": {
+                                              "type": [
+                                                "object",
+                                                "null"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
+                                                  "items": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "matchLabels": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "additionalProperties": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "storageClassName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "volumeMode": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "volumeName": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "fc": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "lun": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "targetWWNs": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "wwids": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "flexVolume": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "driver": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "options": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "additionalProperties": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "flocker": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "datasetName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "datasetUUID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "gcePersistentDisk": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "partition": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "pdName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "gitRepo": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "directory": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "repository": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "revision": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "glusterfs": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "endpoints": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "hostPath": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "type": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "iscsi": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "chapAuthSession": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "initiatorName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "iqn": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "iscsiInterface": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "lun": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "portals": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "targetPortal": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "nfs": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "path": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "server": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "persistentVolumeClaim": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "claimName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "photonPersistentDisk": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "pdID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "portworxVolume": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "volumeID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "projected": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "sources": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "configMap": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "mode": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "path": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "downwardAPI": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "properties": {
+                                              "fieldRef": {
+                                                "type": [
+                                                  "object",
+                                                  "null"
+                                                ],
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "mode": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "path": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "resourceFieldRef": {
+                                                "type": [
+                                                  "object",
+                                                  "null"
+                                                ],
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "divisor": {
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "secret": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "items": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "object",
+                                              "null"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "mode": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "path": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "optional": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "serviceAccountToken": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "audience": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "expirationSeconds": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ]
+                                        },
+                                        "path": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "quobyte": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "group": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "registry": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "tenant": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "user": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volume": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "rbd": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "image": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "keyring": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "monitors": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "pool": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "user": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "scaleIO": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "gateway": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "protectionDomain": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "sslEnabled": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "storageMode": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePool": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "system": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumeName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "secret": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "defaultMode": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "items": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    },
+                                    "path": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "optional": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "storageos": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "readOnly": {
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              "secretRef": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              },
+                              "volumeName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumeNamespace": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "vsphereVolume": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "fsType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePolicyID": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "storagePolicyName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "volumePath": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "conditions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "message": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "Keycloak",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/keycloak-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloak-keycloak-v1alpha1.json
@@ -1,0 +1,1363 @@
+{
+  "description": "Keycloak is the Schema for the keycloaks API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "Keycloak"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakSpec defines the desired state of Keycloak.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "extensions": {
+          "description": "A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "x-kubernetes-list-type": "set"
+        },
+        "external": {
+          "description": "Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "url": {
+              "description": "The URL to use for the keycloak admin API. Needs to be set if external is true.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "externalAccess": {
+          "description": "Controls external Ingress/Route settings.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "host": {
+              "description": "If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tlsTermination": {
+              "description": "TLS Termination type for the external access. Setting this field to \"reencrypt\" will terminate TLS on the Ingress/Route level. Setting this field to \"passthrough\" will send encrypted traffic to the Pod. If unspecified, defaults to \"reencrypt\". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "externalDatabase": {
+          "description": "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "instances": {
+          "description": "Number of Keycloak instances in HA mode. Default is 1.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "keycloakDeploymentSpec": {
+          "description": "Resources (Requests and Limits) for KeycloakDeployment.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "experimental": {
+              "description": "Experimental section NOTE: This section might change or get removed without any notice. It may also cause the deployment to behave in an unpredictable fashion. Please use with care.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "affinity": {
+                  "description": "Affinity settings",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "nodeAffinity": {
+                      "description": "Describes node affinity scheduling rules for the pod.",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "A node selector term, associated with the corresponding weight.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                              "type": "array",
+                              "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "podAffinity": {
+                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "podAntiAffinity": {
+                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "additionalProperties": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "args": {
+                  "description": "Arguments to the entrypoint. Translates into Container CMD.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "command": {
+                  "description": "Container command. Translates into Container ENTRYPOINT.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "env": {
+                  "description": "List of environment variables to set in the container.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "resource"
+                            ],
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "divisor": {
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": [
+                                  "boolean",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "serviceAccountName": {
+                  "description": "ServiceAccountName settings",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "volumes": {
+                  "description": "Additional volume mounts",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "defaultMode": {
+                      "description": "Permissions mode.",
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "format": "int32"
+                    },
+                    "items": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "required": [
+                          "mountPath"
+                        ],
+                        "properties": {
+                          "configMaps": {
+                            "description": "Allow multiple configmaps to mount to the same directory",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "items": {
+                            "description": "Mount details",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "The key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ],
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "mountPath": {
+                            "description": "An absolute path where to mount it",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Volume name",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "secrets": {
+                            "description": "Secret mount",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "podlabels": {
+              "description": "List of labels to set in the keycloak pods",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "resources": {
+              "description": "Resources (Requests and Limits) for the Pods.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "requests": {
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "migration": {
+          "description": "Specify Migration configuration",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "backups": {
+              "description": "Set it to config backup policy for migration",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "enabled": {
+                  "description": "If set to true, the operator will do database backup before doing migration",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "strategy": {
+              "description": "Specify migration strategy",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "multiAvailablityZones": {
+          "description": "Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "podDisruptionBudget": {
+          "description": "Specify PodDisruptionBudget configuration.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "enabled": {
+              "description": "If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
+        "postgresDeploymentSpec": {
+          "description": "Resources (Requests and Limits) for PostgresDeployment.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "resources": {
+              "description": "Resources (Requests and Limits) for the Pods.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "limits": {
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "requests": {
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "profile": {
+          "description": "Profile used for controlling Operator behavior. Default is empty.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storageClassName": {
+          "description": "Name of the StorageClass for Postgresql Persistent Volume Claim",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unmanaged": {
+          "description": "When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "description": "KeycloakStatus defines the observed state of Keycloak.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "credentialSecret",
+        "internalURL",
+        "message",
+        "phase",
+        "ready",
+        "version"
+      ],
+      "properties": {
+        "credentialSecret": {
+          "description": "The secret where the admin credentials are to be found.",
+          "type": "string"
+        },
+        "externalURL": {
+          "description": "External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "internalURL": {
+          "description": "An internal URL (service name) to be used by the admin client.",
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ].",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "version": {
+          "description": "Version of Keycloak or RHSSO running on the cluster.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "Keycloak",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/keycloakbackup-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakbackup-keycloak-v1alpha1.json
@@ -1,0 +1,199 @@
+{
+  "description": "KeycloakBackup is the Schema for the keycloakbackups API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakBackup"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakBackupSpec defines the desired state of KeycloakBackup.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "aws": {
+          "description": "If provided, an automatic database backup will be created on AWS S3 instead of a local Persistent Volume. If this property is not provided - a local Persistent Volume backup will be chosen.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "credentialsSecretName": {
+              "description": "Provides a secret name used for connecting to AWS S3 Service. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information, please refer to the Operator documentation.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "encryptionKeySecretName": {
+              "description": "If provided, the database backup will be encrypted. Provides a secret name used for encrypting database data. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT: <GPG Recipient> \n For more information, please refer to the Operator documentation.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schedule": {
+              "description": "If specified, it will be used as a schedule for creating a CronJob.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "instanceSelector": {
+          "description": "Selector for looking up Keycloak Custom Resources.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "restore": {
+          "description": "Controls automatic restore behavior. Currently not implemented. \n In the future this will be used to trigger automatic restore for a given KeycloakBackup. Each backup will correspond to a single snapshot of the database (stored either in a Persistent Volume or AWS). If a user wants to restore it, all he/she needs to do is to change this flag to true. Potentially, it will be possible to restore a single backup multiple times.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "storageClassName": {
+          "description": "Name of the StorageClass for Postgresql Backup Persistent Volume Claim",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "description": "KeycloakBackupStatus defines the observed state of KeycloakBackup.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "message",
+        "phase",
+        "ready"
+      ],
+      "properties": {
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ]",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakBackup",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/keycloakbackuplist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakbackuplist-keycloak-v1alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "KeycloakBackupList is a list of KeycloakBackup",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakbackups. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakBackup"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakBackupList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakBackupList",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/keycloakclient-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakclient-keycloak-v1alpha1.json
@@ -1,0 +1,1647 @@
+{
+  "description": "KeycloakClient is the Schema for the keycloakclients API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakClient"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakClientSpec defines the desired state of KeycloakClient.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "client",
+        "realmSelector"
+      ],
+      "properties": {
+        "client": {
+          "description": "Keycloak Client REST object.",
+          "type": "object",
+          "required": [
+            "clientId"
+          ],
+          "properties": {
+            "access": {
+              "description": "Access options.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "adminUrl": {
+              "description": "Application Admin URL.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "attributes": {
+              "description": "Client Attributes.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "authenticationFlowBindingOverrides": {
+              "description": "Authentication Flow Binding Overrides.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "authorizationServicesEnabled": {
+              "description": "True if fine-grained authorization support is enabled for this client.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "authorizationSettings": {
+              "description": "Authorization settings for this resource server.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "allowRemoteResourceManagement": {
+                  "description": "True if resources should be managed remotely by the resource server.",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "clientId": {
+                  "description": "Client ID.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "decisionStrategy": {
+                  "description": "The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "description": "ID.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "Name.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "policies": {
+                  "description": "Policies.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "config": {
+                        "description": "Config.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "decisionStrategy": {
+                        "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "description": "A description for this policy.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "logic": {
+                        "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "The name of this policy.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "owner": {
+                        "description": "Owner.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "description": "Policies.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "resources": {
+                        "description": "Resources.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "resourcesData": {
+                        "description": "Resources Data.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "description": "The attributes associated with the resource.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "displayName": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ownerManagedAccess": {
+                              "description": "True if the access to this resource can be managed by the resource owner.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "description": "The scopes associated with this resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "description": "Set of URIs which are protected by resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "scopes": {
+                        "description": "Scopes.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "scopesData": {
+                        "description": "Scopes Data.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "type": {
+                        "description": "Type.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "policyEnforcementMode": {
+                  "description": "The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "resources": {
+                  "description": "Resources.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "_id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "attributes": {
+                        "description": "The attributes associated with the resource.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "displayName": {
+                        "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "icon_uri": {
+                        "description": "An URI pointing to an icon.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "ownerManagedAccess": {
+                        "description": "True if the access to this resource can be managed by the resource owner.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "scopes": {
+                        "description": "The scopes associated with this resource.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "type": {
+                        "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "uris": {
+                        "description": "Set of URIs which are protected by resource.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "scopes": {
+                  "description": "Authorization Scopes.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "displayName": {
+                        "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "iconUri": {
+                        "description": "An URI pointing to an icon.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "description": "Policies.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "description": "Config.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "description": {
+                              "description": "A description for this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "The name of this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "description": "Owner.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "description": "Policies.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "description": "Resources.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "description": "Resources Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "description": "The attributes associated with the resource.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "displayName": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "description": "An URI pointing to an icon.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ownerManagedAccess": {
+                                    "description": "True if the access to this resource can be managed by the resource owner.",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "description": "The scopes associated with this resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "description": "Set of URIs which are protected by resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "scopes": {
+                              "description": "Scopes.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "description": "Scopes Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "Type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "resources": {
+                        "description": "Resources.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "description": "The attributes associated with the resource.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "displayName": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ownerManagedAccess": {
+                              "description": "True if the access to this resource can be managed by the resource owner.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "description": "The scopes associated with this resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "description": "Set of URIs which are protected by resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "baseUrl": {
+              "description": "Application base URL.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "bearerOnly": {
+              "description": "True if a client supports only Bearer Tokens.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "clientAuthenticatorType": {
+              "description": "What Client authentication type to use.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "clientId": {
+              "description": "Client ID.",
+              "type": "string"
+            },
+            "consentRequired": {
+              "description": "True if Consent Screen is required.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "defaultClientScopes": {
+              "description": "A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultRoles": {
+              "description": "Default Client roles.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "description": {
+              "description": "Client description.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "directAccessGrantsEnabled": {
+              "description": "True if Direct Grant is enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabled": {
+              "description": "Client enabled flag.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "frontchannelLogout": {
+              "description": "True if this client supports Front Channel logout.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "fullScopeAllowed": {
+              "description": "True if Full Scope is allowed.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "id": {
+              "description": "Client ID. If not specified, automatically generated.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "implicitFlowEnabled": {
+              "description": "True if Implicit flow is enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "name": {
+              "description": "Client name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "nodeReRegistrationTimeout": {
+              "description": "Node registration timeout.",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "notBefore": {
+              "description": "Not Before setting.",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "optionalClientScopes": {
+              "description": "A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "protocol": {
+              "description": "Protocol used for this Client.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protocolMappers": {
+              "description": "Protocol Mappers.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "description": "Config options.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "consentRequired": {
+                    "description": "True if Consent Screen is required.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "consentText": {
+                    "description": "Text to use for displaying Consent Screen.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "Protocol Mapper ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Protocol Mapper Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "description": "Protocol to use.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMapper": {
+                    "description": "Protocol Mapper to use",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "publicClient": {
+              "description": "True if this is a public Client.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "redirectUris": {
+              "description": "A list of valid Redirection URLs.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "rootUrl": {
+              "description": "Application root URL.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "secret": {
+              "description": "Client Secret. The Operator will automatically create a Secret based on this value.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "serviceAccountsEnabled": {
+              "description": "True if Service Accounts are enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "standardFlowEnabled": {
+              "description": "True if Standard flow is enabled.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "surrogateAuthRequired": {
+              "description": "Surrogate Authentication Required option.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "useTemplateConfig": {
+              "description": "True to use a Template Config.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "useTemplateMappers": {
+              "description": "True to use Template Mappers.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "useTemplateScope": {
+              "description": "True to use Template Scope.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "webOrigins": {
+              "description": "A list of valid Web Origins.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "realmSelector": {
+          "description": "Selector for looking up KeycloakRealm Custom Resources.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "roles": {
+          "description": "Client Roles",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Role Attributes",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "clientRole": {
+                "description": "Client Role",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "composite": {
+                "description": "Composite",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "composites": {
+                "description": "Composites",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "description": "Map client => []role",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "realm": {
+                    "description": "Realm roles",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              },
+              "containerId": {
+                "description": "Container Id",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "description": {
+                "description": "Description",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "id": {
+                "description": "Id",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "scopeMappings": {
+          "description": "Scope Mappings",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "clientMappings": {
+              "description": "Client Mappings",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "description": "Client",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mappings": {
+                    "description": "Mappings",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Role Attributes",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "description": "Client Role",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "description": "Composite",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "description": "Composites",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "client": {
+                              "description": "Map client => []role",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "description": "Realm roles",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "containerId": {
+                          "description": "Container Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "description": "Description",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "realmMappings": {
+              "description": "Realm Mappings",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "attributes": {
+                    "description": "Role Attributes",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientRole": {
+                    "description": "Client Role",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "composite": {
+                    "description": "Composite",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "composites": {
+                    "description": "Composites",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "client": {
+                        "description": "Map client => []role",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "realm": {
+                        "description": "Realm roles",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "containerId": {
+                    "description": "Container Id",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "description": "Description",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "Id",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "KeycloakClientStatus defines the observed state of KeycloakClient",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "message",
+        "phase",
+        "ready"
+      ],
+      "properties": {
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ]",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakClient",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/keycloakclientlist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakclientlist-keycloak-v1alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "KeycloakClientList is a list of KeycloakClient",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakclients. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakClient"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakClientList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakClientList",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/keycloaklist-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloaklist-k8s-v2alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "KeycloakList is a list of Keycloak",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloaks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.Keycloak"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "KeycloakList",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/keycloaklist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloaklist-keycloak-v1alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "KeycloakList is a list of Keycloak",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloaks. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.Keycloak"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakList",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/keycloakrealm-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakrealm-keycloak-v1alpha1.json
@@ -1,0 +1,2801 @@
+{
+  "description": "KeycloakRealm is the Schema for the keycloakrealms API",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealm"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakRealmSpec defines the desired state of KeycloakRealm.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "realm"
+      ],
+      "properties": {
+        "instanceSelector": {
+          "description": "Selector for looking up Keycloak Custom Resources.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "realm": {
+          "description": "Keycloak Realm REST object.",
+          "type": "object",
+          "required": [
+            "realm"
+          ],
+          "properties": {
+            "accessTokenLifespan": {
+              "description": "Access Token Lifespan",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "accessTokenLifespanForImplicitFlow": {
+              "description": "Access Token Lifespan For Implicit Flow",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "accountTheme": {
+              "description": "Account Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "adminEventsDetailsEnabled": {
+              "description": "Enable admin events details TODO: change to values and use kubebuilder default annotation once supported",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminEventsEnabled": {
+              "description": "Enable events recording TODO: change to values and use kubebuilder default annotation once supported",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminTheme": {
+              "description": "Admin Console Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "authenticationFlows": {
+              "description": "Authentication flows",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "alias",
+                  "authenticationExecutions"
+                ],
+                "properties": {
+                  "alias": {
+                    "description": "Alias",
+                    "type": "string"
+                  },
+                  "authenticationExecutions": {
+                    "description": "Authentication executions",
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "authenticator": {
+                          "description": "Authenticator",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorConfig": {
+                          "description": "Authenticator Config",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorFlow": {
+                          "description": "Authenticator flow",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "flowAlias": {
+                          "description": "Flow Alias",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "description": "Priority",
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int32"
+                        },
+                        "requirement": {
+                          "description": "Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userSetupAllowed": {
+                          "description": "User setup allowed",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "builtIn": {
+                    "description": "Built in",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "description": "Description",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "description": "Provider ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "topLevel": {
+                    "description": "Top level",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "authenticatorConfig": {
+              "description": "Authenticator config",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "alias"
+                ],
+                "properties": {
+                  "alias": {
+                    "description": "Alias",
+                    "type": "string"
+                  },
+                  "config": {
+                    "description": "Config",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "description": "ID",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "bruteForceProtected": {
+              "description": "Brute Force Detection",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "clientScopeMappings": {
+              "description": "Client Scope Mappings",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "description": "Client",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientScope": {
+                      "description": "Client Scope",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "roles": {
+                      "description": "Roles",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "self": {
+                      "description": "Self",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "clientScopes": {
+              "description": "Client scopes",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "description": "Protocol Mappers.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "description": "Config options.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "description": "True if Consent Screen is required.",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "description": "Text to use for displaying Consent Screen.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Protocol Mapper ID.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Protocol Mapper Name.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "description": "Protocol to use.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "description": "Protocol Mapper to use",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "clients": {
+              "description": "A set of Keycloak Clients.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "clientId"
+                ],
+                "properties": {
+                  "access": {
+                    "description": "Access options.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "description": "Application Admin URL.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "description": "Client Attributes.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "description": "Authentication Flow Binding Overrides.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "description": "True if fine-grained authorization support is enabled for this client.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "description": "Authorization settings for this resource server.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "description": "True if resources should be managed remotely by the resource server.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "description": "Client ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "description": "The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "ID.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "Name.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "description": "Policies.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "description": "Config.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "description": {
+                              "description": "A description for this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "The name of this policy.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "description": "Owner.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "description": "Policies.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "description": "Resources.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "description": "Resources Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "description": "The attributes associated with the resource.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "displayName": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "description": "An URI pointing to an icon.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ownerManagedAccess": {
+                                    "description": "True if the access to this resource can be managed by the resource owner.",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "description": "The scopes associated with this resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "description": "Set of URIs which are protected by resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "scopes": {
+                              "description": "Scopes.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "description": "Scopes Data.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "Type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "description": "The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "resources": {
+                        "description": "Resources.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "description": "The attributes associated with the resource.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "displayName": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ownerManagedAccess": {
+                              "description": "True if the access to this resource can be managed by the resource owner.",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "description": "The scopes associated with this resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": {
+                              "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "description": "Set of URIs which are protected by resource.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "scopes": {
+                        "description": "Authorization Scopes.",
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "description": "An URI pointing to an icon.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "description": "ID.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "description": "A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "description": "Policies.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "config": {
+                                    "description": "Config.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "decisionStrategy": {
+                                    "description": "The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "description": {
+                                    "description": "A description for this policy.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "logic": {
+                                    "description": "The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "The name of this policy.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "description": "Owner.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "policies": {
+                                    "description": "Policies.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "Resources.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "resourcesData": {
+                                    "description": "Resources Data.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "_id": {
+                                          "description": "ID.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "attributes": {
+                                          "description": "The attributes associated with the resource.",
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "additionalProperties": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        },
+                                        "displayName": {
+                                          "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "icon_uri": {
+                                          "description": "An URI pointing to an icon.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "ownerManagedAccess": {
+                                          "description": "True if the access to this resource can be managed by the resource owner.",
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "scopes": {
+                                          "description": "The scopes associated with this resource.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          }
+                                        },
+                                        "type": {
+                                          "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "uris": {
+                                          "description": "Set of URIs which are protected by resource.",
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "scopes": {
+                                    "description": "Scopes.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "scopesData": {
+                                    "description": "Scopes Data.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "Type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "resources": {
+                              "description": "Resources.",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "description": "https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "description": "ID.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "description": "The attributes associated with the resource.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "displayName": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "description": "An URI pointing to an icon.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "description": "A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ownerManagedAccess": {
+                                    "description": "True if the access to this resource can be managed by the resource owner.",
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "description": "The scopes associated with this resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    }
+                                  },
+                                  "type": {
+                                    "description": "The type of this resource. It can be used to group different resource instances with the same type.",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "description": "Set of URIs which are protected by resource.",
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "baseUrl": {
+                    "description": "Application base URL.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "description": "True if a client supports only Bearer Tokens.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "clientAuthenticatorType": {
+                    "description": "What Client authentication type to use.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "description": "Client ID.",
+                    "type": "string"
+                  },
+                  "consentRequired": {
+                    "description": "True if Consent Screen is required.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "description": "A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "description": "Default Client roles.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "description": "Client description.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "description": "True if Direct Grant is enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "description": "Client enabled flag.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "description": "True if this client supports Front Channel logout.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "description": "True if Full Scope is allowed.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "description": "Client ID. If not specified, automatically generated.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "description": "True if Implicit flow is enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Client name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "description": "Node registration timeout.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "description": "Not Before setting.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "description": "A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "protocol": {
+                    "description": "Protocol used for this Client.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "description": "Protocol Mappers.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "description": "Config options.",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "description": "True if Consent Screen is required.",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "description": "Text to use for displaying Consent Screen.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Protocol Mapper ID.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Protocol Mapper Name.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "description": "Protocol to use.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "description": "Protocol Mapper to use",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "publicClient": {
+                    "description": "True if this is a public Client.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "description": "A list of valid Redirection URLs.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "rootUrl": {
+                    "description": "Application root URL.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "description": "Client Secret. The Operator will automatically create a Secret based on this value.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "description": "True if Service Accounts are enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "description": "True if Standard flow is enabled.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "description": "Surrogate Authentication Required option.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "description": "True to use a Template Config.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "description": "True to use Template Mappers.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "description": "True to use Template Scope.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "description": "A list of valid Web Origins.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "defaultLocale": {
+              "description": "Default Locale",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "defaultRole": {
+              "description": "Default role",
+              "type": [
+                "object",
+                "null"
+              ],
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "attributes": {
+                  "description": "Role Attributes",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "clientRole": {
+                  "description": "Client Role",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composite": {
+                  "description": "Composite",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composites": {
+                  "description": "Composites",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "description": "Map client => []role",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "realm": {
+                      "description": "Realm roles",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "containerId": {
+                  "description": "Container Id",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "description": {
+                  "description": "Description",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "description": "Id",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "description": "Name",
+                  "type": "string"
+                }
+              }
+            },
+            "displayName": {
+              "description": "Realm display name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "displayNameHtml": {
+              "description": "Realm HTML display name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "duplicateEmailsAllowed": {
+              "description": "Duplicate emails",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "editUsernameAllowed": {
+              "description": "Edit username",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "emailTheme": {
+              "description": "Email Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enabled": {
+              "description": "Realm enabled flag.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabledEventTypes": {
+              "description": "Enabled event types",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "eventsEnabled": {
+              "description": "Enable events recording TODO: change to values and use kubebuilder default annotation once supported",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "eventsListeners": {
+              "description": "A set of Event Listeners.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "failureFactor": {
+              "description": "Max Login Failures",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identityProviders": {
+              "description": "A set of Identity Providers.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addReadTokenRoleOnCreate": {
+                    "description": "Adds Read Token role when creating this Identity Provider.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "alias": {
+                    "description": "Identity Provider Alias.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "description": "Identity Provider config.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "description": "Identity Provider Display Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "description": "Identity Provider enabled flag.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "firstBrokerLoginFlowAlias": {
+                    "description": "Identity Provider First Broker Login Flow Alias.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "internalId": {
+                    "description": "Identity Provider Internal ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "linkOnly": {
+                    "description": "Identity Provider Link Only setting.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "postBrokerLoginFlowAlias": {
+                    "description": "Identity Provider Post Broker Login Flow Alias.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "description": "Identity Provider ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "storeToken": {
+                    "description": "Identity Provider Store to Token.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "trustEmail": {
+                    "description": "Identity Provider Trust Email.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "internationalizationEnabled": {
+              "description": "Internationalization Enabled",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "loginTheme": {
+              "description": "Login Theme",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loginWithEmailAllowed": {
+              "description": "Login with email",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "maxDeltaTimeSeconds": {
+              "description": "Failure Reset Time",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "maxFailureWaitSeconds": {
+              "description": "Max Wait",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "minimumQuickLoginWaitSeconds": {
+              "description": "Minimum Quick Login Wait",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "passwordPolicy": {
+              "description": "Realm Password Policy",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "permanentLockout": {
+              "description": "Permanent Lockout",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "quickLoginCheckMilliSeconds": {
+              "description": "Quick Login Check Milli Seconds",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "realm": {
+              "description": "Realm name.",
+              "type": "string"
+            },
+            "registrationAllowed": {
+              "description": "User registration",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "registrationEmailAsUsername": {
+              "description": "Email as username",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "rememberMe": {
+              "description": "Remember me",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "resetPasswordAllowed": {
+              "description": "Forgot password",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "roles": {
+              "description": "Roles",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "client": {
+                  "description": "Client Roles",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Role Attributes",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "description": "Client Role",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "description": "Composite",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "description": "Composites",
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "client": {
+                              "description": "Map client => []role",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "description": "Realm roles",
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "containerId": {
+                          "description": "Container Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "description": "Description",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "description": "Id",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "realm": {
+                  "description": "Realm Roles",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "description": "Role Attributes",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "clientRole": {
+                        "description": "Client Role",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composite": {
+                        "description": "Composite",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composites": {
+                        "description": "Composites",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "client": {
+                            "description": "Map client => []role",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "realm": {
+                            "description": "Realm roles",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "containerId": {
+                        "description": "Container Id",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "description": "Description",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "description": "Id",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "description": "Name",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "scopeMappings": {
+              "description": "Scope Mappings",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "description": "Client",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientScope": {
+                    "description": "Client Scope",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "roles": {
+                    "description": "Roles",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "description": "Self",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "smtpServer": {
+              "description": "Email",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "sslRequired": {
+              "description": "Require SSL",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supportedLocales": {
+              "description": "Supported Locales",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "userFederationMappers": {
+              "description": "User federation mappers are extension points triggered by the user federation at various points.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "description": "User federation mapper config.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "federationMapperType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "federationProviderDisplayName": {
+                    "description": "The displayName for the user federation provider this mapper applies to.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "userFederationProviders": {
+              "description": "Point keycloak to an external user provider to validate credentials or pull in identity information.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "description": "User federation provider config.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "description": "The display name of this provider instance.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fullSyncPeriod": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int32"
+                  },
+                  "id": {
+                    "description": "The ID of this provider",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "priority": {
+                    "description": "The priority of this provider when looking up users or adding a user.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int32"
+                  },
+                  "providerName": {
+                    "description": "The name of the user provider, such as \"ldap\", \"kerberos\" or a custom SPI.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "userManagedAccessAllowed": {
+              "description": "User Managed Access Allowed",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "users": {
+              "description": "A set of Keycloak Users.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "description": "A set of Attributes.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientRoles": {
+                    "description": "A set of Client Roles.",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "description": "A set of Credentials.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "temporary": {
+                          "description": "True if this credential object is temporary.",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "description": "Credential Type.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "value": {
+                          "description": "Credential Value.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "email": {
+                    "description": "Email.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "description": "True if email has already been verified.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "description": "User enabled flag.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "federatedIdentities": {
+                    "description": "A set of Federated Identities.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "identityProvider": {
+                          "description": "Federated Identity Provider.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userId": {
+                          "description": "Federated Identity User ID.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userName": {
+                          "description": "Federated Identity User Name.",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "firstName": {
+                    "description": "First Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "groups": {
+                    "description": "A set of Groups.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "description": "User ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastName": {
+                    "description": "Last Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "description": "A set of Realm Roles.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "requiredActions": {
+                    "description": "A set of Required Actions.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "username": {
+                    "description": "User Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "verifyEmail": {
+              "description": "Verify email",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "waitIncrementSeconds": {
+              "description": "Wait Increment",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            }
+          }
+        },
+        "realmOverrides": {
+          "description": "A list of overrides to the default Realm behavior.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "identityProvider"
+            ],
+            "properties": {
+              "forFlow": {
+                "description": "Flow to be overridden.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "identityProvider": {
+                "description": "Identity Provider to be overridden.",
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-type": "atomic"
+        },
+        "unmanaged": {
+          "description": "When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "status": {
+      "description": "KeycloakRealmStatus defines the observed state of KeycloakRealm",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "loginURL",
+        "message",
+        "phase",
+        "ready"
+      ],
+      "properties": {
+        "loginURL": {
+          "description": "TODO",
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "True if all resources are in a ready state and all work is done.",
+          "type": "boolean"
+        },
+        "secondaryResources": {
+          "description": "A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ]",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakRealm",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/keycloakrealmimport-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakrealmimport-k8s-v2alpha1.json
@@ -1,0 +1,6484 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealmImport"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "keycloakCRName",
+        "realm"
+      ],
+      "properties": {
+        "keycloakCRName": {
+          "description": "The name of the Keycloak CR to reference, in the same namespace.",
+          "type": "string"
+        },
+        "realm": {
+          "description": "The RealmRepresentation to import into Keycloak.",
+          "type": "object",
+          "properties": {
+            "accessCodeLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessCodeLifespanLogin": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessCodeLifespanUserAction": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessTokenLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accessTokenLifespanForImplicitFlow": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "accountTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "actionTokenGeneratedByAdminLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "actionTokenGeneratedByUserLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "adminEventsDetailsEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminEventsEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "adminTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "applicationScopeMappings": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientScope": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientTemplate": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "roles": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "self": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "applications": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alwaysDisplayInConsole": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "AFFIRMATIVE",
+                          "CONSENSUS",
+                          "UNANIMOUS"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "AFFIRMATIVE",
+                                "CONSENSUS",
+                                "UNANIMOUS"
+                              ]
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "POSITIVE",
+                                "NEGATIVE"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "id": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "ownerManagedAccess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "displayName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "iconUri": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "id": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "PERMISSIVE",
+                          "ENFORCING",
+                          "DISABLED"
+                        ]
+                      },
+                      "resources": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "ownerManagedAccess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "scopes": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "baseUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "claims": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "address": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "email": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "gender": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "locale": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "phone": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "picture": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "profile": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "username": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "website": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientAuthenticatorType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "directGrantsOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "oauth2DeviceAuthorizationGrantEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registeredNodes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registrationAccessToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rootUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "attributes": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "authenticationFlows": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "authenticationExecutions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "authenticator": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorConfig": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authenticatorFlow": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "autheticatorFlow": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "flowAlias": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "requirement": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userSetupAllowed": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "builtIn": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "topLevel": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "authenticatorConfig": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "browserFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "browserSecurityHeaders": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "bruteForceProtected": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "certificate": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "clientAuthenticationFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "clientOfflineSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientOfflineSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientPolicies": {
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "clientProfiles": {
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "clientScopeMappings": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "client": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientScope": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "clientTemplate": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "roles": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "self": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "clientScopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "clientSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "clientTemplates": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "clients": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alwaysDisplayInConsole": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "AFFIRMATIVE",
+                          "CONSENSUS",
+                          "UNANIMOUS"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "AFFIRMATIVE",
+                                "CONSENSUS",
+                                "UNANIMOUS"
+                              ]
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "POSITIVE",
+                                "NEGATIVE"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "id": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "ownerManagedAccess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "displayName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "iconUri": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "id": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "PERMISSIVE",
+                          "ENFORCING",
+                          "DISABLED"
+                        ]
+                      },
+                      "resources": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "ownerManagedAccess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "scopes": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "baseUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "clientAuthenticatorType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "directGrantsOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "oauth2DeviceAuthorizationGrantEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registeredNodes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registrationAccessToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rootUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "codeSecret": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "components": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "config": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "providerId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "subComponents": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "providerId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "subType": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "subType": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "defaultDefaultClientScopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultGroups": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultLocale": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "defaultOptionalClientScopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultRole": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "attributes": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "clientRole": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composite": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "composites": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "application": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "client": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "realm": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "containerId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "scopeParamRequired": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "defaultRoles": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "defaultSignatureAlgorithm": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "directGrantFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "displayName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "displayNameHtml": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "dockerAuthenticationFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "duplicateEmailsAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "editUsernameAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "emailTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabledEventTypes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "eventsEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "eventsExpiration": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "eventsListeners": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "failureFactor": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "federatedUsers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "applicationRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientConsents": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "clientId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "grantedClientScopes": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "grantedRealmRoles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "lastUpdatedDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "clientRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "createdTimestamp": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "credentials": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "algorithm": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "counter": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "credentialData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "device": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "digits": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashIterations": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashedSaltedValue": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "period": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "salt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "secretData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "temporary": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userLabel": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "value": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "disableableCredentialTypes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "email": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "federatedIdentities": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "identityProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "federationLink": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "firstName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "groups": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "requiredActions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountClientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "socialLinks": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "socialProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUserId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUsername": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "totp": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "username": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "groups": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "path": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "subGroups": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "access": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
+                        },
+                        "attributes": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRoles": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "path": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "realmRoles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identityProviderMappers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "identityProviderAlias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "identityProviderMapper": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "identityProviders": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "addReadTokenRoleOnCreate": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "authenticateByDefault": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "firstBrokerLoginFlowAlias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "internalId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "linkOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "postBrokerLoginFlowAlias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "storeToken": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "trustEmail": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "updateProfileFirstLoginMode": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "internationalizationEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "keycloakVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loginTheme": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "loginWithEmailAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "maxDeltaTimeSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "maxFailureWaitSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minimumQuickLoginWaitSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "notBefore": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "oauth2DeviceCodeLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "oauth2DevicePollingInterval": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "oauthClients": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "adminUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alwaysDisplayInConsole": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authenticationFlowBindingOverrides": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "authorizationServicesEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "authorizationSettings": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "allowRemoteResourceManagement": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "clientId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "decisionStrategy": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "AFFIRMATIVE",
+                          "CONSENSUS",
+                          "UNANIMOUS"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policies": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "config": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "decisionStrategy": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "AFFIRMATIVE",
+                                "CONSENSUS",
+                                "UNANIMOUS"
+                              ]
+                            },
+                            "description": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "logic": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "enum": [
+                                "POSITIVE",
+                                "NEGATIVE"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "policies": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resources": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "resourcesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "_id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "attributes": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "icon_uri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "owner": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "id": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "name": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "ownerManagedAccess": {
+                                    "type": [
+                                      "boolean",
+                                      "null"
+                                    ]
+                                  },
+                                  "scopes": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "object",
+                                        "null"
+                                      ],
+                                      "properties": {
+                                        "displayName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "iconUri": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "id": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "type": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "uris": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "scopesData": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "policyEnforcementMode": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "enum": [
+                          "PERMISSIVE",
+                          "ENFORCING",
+                          "DISABLED"
+                        ]
+                      },
+                      "resources": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "_id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "attributes": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "icon_uri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "owner": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "name": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "ownerManagedAccess": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "scopes": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "displayName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "iconUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "id": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "uris": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "scopes": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "displayName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "iconUri": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "id": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "baseUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bearerOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "claims": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "address": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "email": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "gender": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "locale": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "phone": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "picture": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "profile": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "username": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "website": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientAuthenticatorType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "defaultClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "directAccessGrantsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "directGrantsOnly": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "frontchannelLogout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "fullScopeAllowed": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "implicitFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nodeReRegistrationTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "oauth2DeviceAuthorizationGrantEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "optionalClientScopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMappers": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "consentRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "consentText": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocol": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "protocolMapper": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "publicClient": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "redirectUris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registeredNodes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  },
+                  "registrationAccessToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rootUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "secret": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountsEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "standardFlowEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "surrogateAuthRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateConfig": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateMappers": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "useTemplateScope": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "webOrigins": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "offlineSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "offlineSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "offlineSessionMaxLifespanEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "otpPolicyAlgorithm": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "otpPolicyDigits": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyInitialCounter": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyLookAheadWindow": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyPeriod": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "otpPolicyType": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "otpSupportedApplications": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "passwordCredentialGrantAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "passwordPolicy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "permanentLockout": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "privateKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protocolMappers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "consentRequired": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "consentText": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "protocolMapper": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "publicKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "quickLoginCheckMilliSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "realm": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "realmCacheEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "refreshTokenMaxReuse": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "registrationAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "registrationEmailAsUsername": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "registrationFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "rememberMe": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "requiredActions": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "defaultAction": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "priority": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "requiredCredentials": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "resetCredentialsFlow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resetPasswordAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "revokeRefreshToken": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "roles": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "application": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "application": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "client": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "containerId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "scopeParamRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "client": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "clientRole": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composite": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "composites": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "application": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "client": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              }
+                            },
+                            "realm": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "containerId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "scopeParamRequired": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "realm": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "clientRole": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composite": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "composites": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "application": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "client": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "realm": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "containerId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "scopeParamRequired": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "scopeMappings": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "client": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientScope": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clientTemplate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "roles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "smtpServer": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "social": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "socialProviders": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "sslRequired": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ssoSessionIdleTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ssoSessionIdleTimeoutRememberMe": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ssoSessionMaxLifespan": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ssoSessionMaxLifespanRememberMe": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "supportedLocales": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "updateProfileOnInitialSocialLogin": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "userCacheEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "userFederationMappers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "federationMapperType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "federationProviderDisplayName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "userFederationProviders": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "changedSyncPeriod": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "displayName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fullSyncPeriod": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastSync": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "priority": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "providerName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "userManagedAccessAllowed": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "users": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "access": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    }
+                  },
+                  "applicationRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "clientConsents": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "clientId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "grantedClientScopes": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "grantedRealmRoles": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "lastUpdatedDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "clientRoles": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "createdTimestamp": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "credentials": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "algorithm": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "config": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "counter": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "createdDate": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "credentialData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "device": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "digits": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashIterations": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "hashedSaltedValue": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "period": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "priority": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "salt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "secretData": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "temporary": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userLabel": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "value": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "disableableCredentialTypes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "email": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "federatedIdentities": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "identityProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "userName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "federationLink": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "firstName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "groups": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "notBefore": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "origin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "realmRoles": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "requiredActions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "self": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "serviceAccountClientId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "socialLinks": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "socialProvider": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUserId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "socialUsername": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "totp": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "username": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "verifyEmail": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "waitIncrementSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "webAuthnPolicyAcceptableAaguids": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyAttestationConveyancePreference": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyAuthenticatorAttachment": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "webAuthnPolicyCreateTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessAcceptableAaguids": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessCreateTimeout": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessRequireResidentKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessRpEntityName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessRpId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyRequireResidentKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyRpEntityName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicyRpId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "webAuthnPolicySignatureAlgorithms": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "webAuthnPolicyUserVerificationRequirement": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "conditions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "message": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "KeycloakRealmImport",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/keycloakrealmimportlist-k8s-v2alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakrealmimportlist-k8s-v2alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "KeycloakRealmImportList is a list of KeycloakRealmImport",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "k8s.keycloak.org/v2alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakrealmimports. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.k8s.v2alpha1.KeycloakRealmImport"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealmImportList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "k8s.keycloak.org",
+      "kind": "KeycloakRealmImportList",
+      "version": "v2alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/keycloakrealmlist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakrealmlist-keycloak-v1alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "KeycloakRealmList is a list of KeycloakRealm",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakrealms. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakRealm"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakRealmList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakRealmList",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/keycloakuser-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakuser-keycloak-v1alpha1.json
@@ -1,0 +1,338 @@
+{
+  "description": "KeycloakUser is the Schema for the keycloakusers API.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakUser"
+      ]
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+    },
+    "spec": {
+      "description": "KeycloakUserSpec defines the desired state of KeycloakUser.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "user"
+      ],
+      "properties": {
+        "realmSelector": {
+          "description": "Selector for looking up KeycloakRealm Custom Resources.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "user": {
+          "description": "Keycloak User REST object.",
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "description": "A set of Attributes.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "clientRoles": {
+              "description": "A set of Client Roles.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "credentials": {
+              "description": "A set of Credentials.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "temporary": {
+                    "description": "True if this credential object is temporary.",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "description": "Credential Type.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "value": {
+                    "description": "Credential Value.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "email": {
+              "description": "Email.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "emailVerified": {
+              "description": "True if email has already been verified.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "enabled": {
+              "description": "User enabled flag.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "federatedIdentities": {
+              "description": "A set of Federated Identities.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "identityProvider": {
+                    "description": "Federated Identity Provider.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "userId": {
+                    "description": "Federated Identity User ID.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "userName": {
+                    "description": "Federated Identity User Name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "firstName": {
+              "description": "First Name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "groups": {
+              "description": "A set of Groups.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "id": {
+              "description": "User ID.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lastName": {
+              "description": "Last Name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "realmRoles": {
+              "description": "A set of Realm Roles.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "requiredActions": {
+              "description": "A set of Required Actions.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "username": {
+              "description": "User Name.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "KeycloakUserStatus defines the observed state of KeycloakUser.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "message",
+        "phase"
+      ],
+      "properties": {
+        "message": {
+          "description": "Human-readable message indicating details about current operator phase or error.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Current phase of the operator.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakUser",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/openshift-json-schema/master-standalone/keycloakuserlist-keycloak-v1alpha1.json
+++ b/openshift-json-schema/master-standalone/keycloakuserlist-keycloak-v1alpha1.json
@@ -1,0 +1,51 @@
+{
+  "description": "KeycloakUserList is a list of KeycloakUser",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "keycloak.org/v1alpha1"
+      ]
+    },
+    "items": {
+      "description": "List of keycloakusers. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/org.keycloak.v1alpha1.KeycloakUser"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "KeycloakUserList"
+      ]
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "keycloak.org",
+      "kind": "KeycloakUserList",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/openshift-json-schema/master-standalone/localsubjectaccessreview-authorization-v1.json
+++ b/openshift-json-schema/master-standalone/localsubjectaccessreview-authorization-v1.json
@@ -1,18 +1,8 @@
 {
-  "description": "LocalSubjectAccessReview is an object for requesting information about whether a user or group can perform an action in a particular namespace\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
   "type": "object",
   "required": [
-    "namespace",
-    "verb",
-    "resourceAPIGroup",
-    "resourceAPIVersion",
-    "resource",
-    "resourceName",
-    "path",
-    "isNonResourceURL",
-    "user",
-    "groups",
-    "scopes"
+    "spec"
   ],
   "properties": {
     "apiVersion": {
@@ -22,32 +12,7 @@
         "null"
       ],
       "enum": [
-        "v1",
-        "authorization.openshift.io/v1"
-      ]
-    },
-    "content": {
-      "description": "Content is the actual content of the request for create and update",
-      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
-    },
-    "groups": {
-      "description": "Groups is optional.  Groups is the list of groups to which the User belongs.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": [
-          "string",
-          "null"
-        ]
-      }
-    },
-    "isNonResourceURL": {
-      "description": "IsNonResourceURL is true if this is a request for a non-resource URL (outside of the resource hierarchy)",
-      "type": [
-        "boolean",
-        "null"
+        "authorization.k8s.io/v1"
       ]
     },
     "kind": {
@@ -60,84 +25,22 @@
         "LocalSubjectAccessReview"
       ]
     },
-    "namespace": {
-      "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces",
-      "type": [
-        "string",
-        "null"
-      ]
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
-    "path": {
-      "description": "Path is the path of a non resource URL",
-      "type": [
-        "string",
-        "null"
-      ]
+    "spec": {
+      "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
+      "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec"
     },
-    "resource": {
-      "description": "Resource is one of the existing resource types",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "resourceAPIGroup": {
-      "description": "Group is the API group of the resource Serialized as resourceAPIGroup to avoid confusion with the 'groups' field when inlined",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "resourceAPIVersion": {
-      "description": "Version is the API version of the resource Serialized as resourceAPIVersion to avoid confusion with TypeMeta.apiVersion and ObjectMeta.resourceVersion when inlined",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "resourceName": {
-      "description": "ResourceName is the name of the resource being requested for a \"get\" or deleted for a \"delete\"",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "scopes": {
-      "description": "Scopes to use for the evaluation.  Empty means \"use the unscoped (full) permissions of the user/groups\". Nil for a self-SAR, means \"use the scopes on this request\". Nil for a regular SAR, means the same as empty.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": [
-          "string",
-          "null"
-        ]
-      }
-    },
-    "user": {
-      "description": "User is optional.  If both User and Groups are empty, the current authenticated user is used.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "verb": {
-      "description": "Verb is one of: get, list, watch, create, update, delete",
-      "type": [
-        "string",
-        "null"
-      ]
+    "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "",
-      "kind": "LocalSubjectAccessReview",
-      "version": "v1"
-    },
-    {
-      "group": "authorization.openshift.io",
+      "group": "authorization.k8s.io",
       "kind": "LocalSubjectAccessReview",
       "version": "v1"
     }

--- a/openshift-json-schema/master-standalone/rangeallocation-security-v1.json
+++ b/openshift-json-schema/master-standalone/rangeallocation-security-v1.json
@@ -1,10 +1,6 @@
 {
-  "description": "RangeAllocation is used so we can easily expose a RangeAllocation typed for security group\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "RangeAllocation is used so we can easily expose a RangeAllocation typed for security group This is an internal API, not intended for external consumption. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
   "type": "object",
-  "required": [
-    "range",
-    "data"
-  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,7 +9,7 @@
         "null"
       ],
       "enum": [
-        "security.openshift.io/v1"
+        "security.internal.openshift.io/v1"
       ]
     },
     "data": {
@@ -21,8 +17,7 @@
       "type": [
         "string",
         "null"
-      ],
-      "format": "byte"
+      ]
     },
     "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
@@ -35,7 +30,8 @@
       ]
     },
     "metadata": {
-      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
     },
     "range": {
       "description": "range is a string representing a unique label for a range of uids, \"1000000000-2000000000/10000\".",
@@ -47,7 +43,7 @@
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "security.openshift.io",
+      "group": "security.internal.openshift.io",
       "kind": "RangeAllocation",
       "version": "v1"
     }

--- a/openshift-json-schema/master-standalone/rangeallocationlist-security-v1.json
+++ b/openshift-json-schema/master-standalone/rangeallocationlist-security-v1.json
@@ -1,6 +1,5 @@
 {
-  "description": "RangeAllocationList is a list of RangeAllocations objects\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
-  "type": "object",
+  "description": "RangeAllocationList is a list of RangeAllocation",
   "required": [
     "items"
   ],
@@ -12,17 +11,17 @@
         "null"
       ],
       "enum": [
-        "security.openshift.io/v1"
+        "security.internal.openshift.io/v1"
       ]
     },
     "items": {
-      "description": "List of RangeAllocations.",
+      "description": "List of rangeallocations. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "_definitions.json#/definitions/com.github.openshift.api.security.v1.RangeAllocation"
+        "$ref": "_definitions.json#/definitions/io.openshift.internal.security.v1.RangeAllocation"
       }
     },
     "kind": {
@@ -36,15 +35,17 @@
       ]
     },
     "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "security.openshift.io",
+      "group": "security.internal.openshift.io",
       "kind": "RangeAllocationList",
       "version": "v1"
     }
   ],
-  "$schema": "http://json-schema.org/schema#"
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
 }

--- a/openshift-json-schema/master-standalone/selfsubjectrulesreview-authorization-v1.json
+++ b/openshift-json-schema/master-standalone/selfsubjectrulesreview-authorization-v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.",
   "type": "object",
   "required": [
     "spec"
@@ -12,8 +12,7 @@
         "null"
       ],
       "enum": [
-        "v1",
-        "authorization.openshift.io/v1"
+        "authorization.k8s.io/v1"
       ]
     },
     "kind": {
@@ -26,23 +25,22 @@
         "SelfSubjectRulesReview"
       ]
     },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
     "spec": {
-      "description": "Spec adds information about how to conduct the check",
-      "$ref": "_definitions.json#/definitions/com.github.openshift.api.authorization.v1.SelfSubjectRulesReviewSpec"
+      "description": "Spec holds information about the request being evaluated.",
+      "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec"
     },
     "status": {
-      "description": "Status is completed by the server to tell which permissions you have",
-      "$ref": "_definitions.json#/definitions/com.github.openshift.api.authorization.v1.SubjectRulesReviewStatus"
+      "description": "Status is filled in by the server and indicates the set of actions a user can perform.",
+      "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.SubjectRulesReviewStatus"
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "",
-      "kind": "SelfSubjectRulesReview",
-      "version": "v1"
-    },
-    {
-      "group": "authorization.openshift.io",
+      "group": "authorization.k8s.io",
       "kind": "SelfSubjectRulesReview",
       "version": "v1"
     }

--- a/openshift-json-schema/master-standalone/selfsubjectrulesreviewspec-authorization-v1.json
+++ b/openshift-json-schema/master-standalone/selfsubjectrulesreviewspec-authorization-v1.json
@@ -1,22 +1,13 @@
 {
-  "description": "SelfSubjectRulesReviewSpec adds information about how to conduct the check",
+  "description": "SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.",
   "type": "object",
-  "required": [
-    "scopes"
-  ],
   "properties": {
-    "scopes": {
-      "description": "Scopes to use for the evaluation.  Empty means \"use the unscoped (full) permissions of the user/groups\". Nil means \"use the scopes on this request\".",
+    "namespace": {
+      "description": "Namespace to evaluate rules for. Required.",
       "type": [
-        "array",
+        "string",
         "null"
-      ],
-      "items": {
-        "type": [
-          "string",
-          "null"
-        ]
-      }
+      ]
     }
   },
   "$schema": "http://json-schema.org/schema#"

--- a/openshift-json-schema/master-standalone/subjectaccessreview-authorization-v1.json
+++ b/openshift-json-schema/master-standalone/subjectaccessreview-authorization-v1.json
@@ -1,18 +1,8 @@
 {
-  "description": "SubjectAccessReview is an object for requesting information about whether a user or group can perform an action\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
   "type": "object",
   "required": [
-    "namespace",
-    "verb",
-    "resourceAPIGroup",
-    "resourceAPIVersion",
-    "resource",
-    "resourceName",
-    "path",
-    "isNonResourceURL",
-    "user",
-    "groups",
-    "scopes"
+    "spec"
   ],
   "properties": {
     "apiVersion": {
@@ -22,32 +12,7 @@
         "null"
       ],
       "enum": [
-        "v1",
-        "authorization.openshift.io/v1"
-      ]
-    },
-    "content": {
-      "description": "Content is the actual content of the request for create and update",
-      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
-    },
-    "groups": {
-      "description": "GroupsSlice is optional. Groups is the list of groups to which the User belongs.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": [
-          "string",
-          "null"
-        ]
-      }
-    },
-    "isNonResourceURL": {
-      "description": "IsNonResourceURL is true if this is a request for a non-resource URL (outside of the resource hierarchy)",
-      "type": [
-        "boolean",
-        "null"
+        "authorization.k8s.io/v1"
       ]
     },
     "kind": {
@@ -60,84 +25,22 @@
         "SubjectAccessReview"
       ]
     },
-    "namespace": {
-      "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces",
-      "type": [
-        "string",
-        "null"
-      ]
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
-    "path": {
-      "description": "Path is the path of a non resource URL",
-      "type": [
-        "string",
-        "null"
-      ]
+    "spec": {
+      "description": "Spec holds information about the request being evaluated",
+      "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec"
     },
-    "resource": {
-      "description": "Resource is one of the existing resource types",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "resourceAPIGroup": {
-      "description": "Group is the API group of the resource Serialized as resourceAPIGroup to avoid confusion with the 'groups' field when inlined",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "resourceAPIVersion": {
-      "description": "Version is the API version of the resource Serialized as resourceAPIVersion to avoid confusion with TypeMeta.apiVersion and ObjectMeta.resourceVersion when inlined",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "resourceName": {
-      "description": "ResourceName is the name of the resource being requested for a \"get\" or deleted for a \"delete\"",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "scopes": {
-      "description": "Scopes to use for the evaluation.  Empty means \"use the unscoped (full) permissions of the user/groups\". Nil for a self-SAR, means \"use the scopes on this request\". Nil for a regular SAR, means the same as empty.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": [
-          "string",
-          "null"
-        ]
-      }
-    },
-    "user": {
-      "description": "User is optional. If both User and Groups are empty, the current authenticated user is used.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "verb": {
-      "description": "Verb is one of: get, list, watch, create, update, delete",
-      "type": [
-        "string",
-        "null"
-      ]
+    "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "",
-      "kind": "SubjectAccessReview",
-      "version": "v1"
-    },
-    {
-      "group": "authorization.openshift.io",
+      "group": "authorization.k8s.io",
       "kind": "SubjectAccessReview",
       "version": "v1"
     }

--- a/openshift-json-schema/master-standalone/subjectrulesreviewstatus-authorization-v1.json
+++ b/openshift-json-schema/master-standalone/subjectrulesreviewstatus-authorization-v1.json
@@ -1,25 +1,44 @@
 {
-  "description": "SubjectRulesReviewStatus is contains the result of a rules check",
+  "description": "SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on the set of authorizers the server is configured with and any errors experienced during evaluation. Because authorization rules are additive, if a rule appears in a list it's safe to assume the subject has that permission, even if that list is incomplete.",
   "type": "object",
   "required": [
-    "rules"
+    "resourceRules",
+    "nonResourceRules",
+    "incomplete"
   ],
   "properties": {
     "evaluationError": {
-      "description": "EvaluationError can appear in combination with Rules.  It means some error happened during evaluation that may have prevented additional rules from being populated.",
+      "description": "EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.",
       "type": [
         "string",
         "null"
       ]
     },
-    "rules": {
-      "description": "Rules is the list of rules (no particular sort) that are allowed for the subject",
+    "incomplete": {
+      "description": "Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nonResourceRules": {
+      "description": "NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "_definitions.json#/definitions/com.github.openshift.api.authorization.v1.PolicyRule"
+        "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.NonResourceRule"
+      }
+    },
+    "resourceRules": {
+      "description": "ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.k8s.api.authorization.v1.ResourceRule"
       }
     }
   },


### PR DESCRIPTION
Endringen inneholder schemas for Keycloak og AMQ. I tillegg måtte eksemplet korrigeres, da `strict` krever et `true` parameter for å gå gjennom. Fjernet også litt tomme linjer for at `markdownlint` skulle bli fornøyd.